### PR TITLE
Add cost and category tracking to flights

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -70,6 +70,10 @@ model Flight {
   terminal          String?
   bookingReference  String?  @map("booking_reference")
   ticketNumber      String?  @map("ticket_number")
+  ticketPrice       Float?   @map("ticket_price")
+  currency          String   @default("EUR")
+  category          String   @default("private") // business, private, vacation
+  tags              String[] @default([])
   createdAt         DateTime @default(now()) @map("created_at")
 
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)

--- a/backend/src/routes/flights.ts
+++ b/backend/src/routes/flights.ts
@@ -38,6 +38,10 @@ router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => 
         arrivalTime: new Date(data.arrivalTime),
         status: data.status,
         notes: data.notes,
+        ticketPrice: data.ticketPrice,
+        currency: data.currency,
+        category: data.category,
+        tags: data.tags,
       },
     });
 
@@ -229,6 +233,10 @@ router.put('/:id', async (req: AuthRequest, res: Response, next: NextFunction) =
     if (data.aircraft !== undefined) updateData.aircraft = data.aircraft;
     if (data.status) updateData.status = data.status;
     if (data.notes !== undefined) updateData.notes = data.notes;
+    if (data.ticketPrice !== undefined) updateData.ticketPrice = data.ticketPrice;
+    if (data.currency !== undefined) updateData.currency = data.currency;
+    if (data.category) updateData.category = data.category;
+    if (data.tags !== undefined) updateData.tags = data.tags;
 
     if (data.departure) {
       updateData.depIcao = data.departure.icao;

--- a/backend/src/schemas/flight.ts
+++ b/backend/src/schemas/flight.ts
@@ -31,6 +31,10 @@ const baseFlightSchema = z.object({
   arrivalTime: z.string().datetime(),
   status: z.enum(['scheduled', 'flown', 'cancelled']).default('scheduled'),
   notes: z.string().optional(),
+  ticketPrice: z.number().positive().optional(),
+  currency: z.string().min(1).default('EUR').optional(),
+  category: z.enum(['business', 'private', 'vacation']).default('private'),
+  tags: z.array(z.string()).default([]),
 });
 
 export const createFlightSchema = baseFlightSchema.refine(

--- a/frontend/src/components/FlightForm.tsx
+++ b/frontend/src/components/FlightForm.tsx
@@ -33,6 +33,10 @@ export default function FlightForm({ onSubmit, onCancel }: FlightFormProps) {
     arrivalTime: '',
     status: 'scheduled',
     notes: '',
+    ticketPrice: undefined,
+    currency: 'EUR',
+    category: 'private',
+    tags: [],
   });
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -296,19 +300,89 @@ export default function FlightForm({ onSubmit, onCancel }: FlightFormProps) {
                   <option value="cancelled">Cancelled</option>
                 </select>
               </div>
+        </div>
+      </div>
+
+      {/* Costs & Categorization */}
+      <div className="space-y-4">
+        <h3 className="font-semibold text-lg">Kosten & Kategorien</h3>
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="label">Ticketpreis</label>
+            <div className="flex gap-2">
+              <input
+                type="number"
+                min="0"
+                step="0.01"
+                value={formData.ticketPrice ?? ''}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    ticketPrice: e.target.value ? parseFloat(e.target.value) : undefined,
+                  })
+                }
+                className="input flex-1"
+                placeholder="z.B. 249.99"
+              />
+              <select
+                value={formData.currency}
+                onChange={(e) => setFormData({ ...formData, currency: e.target.value })}
+                className="input w-24"
+              >
+                <option value="EUR">EUR</option>
+                <option value="USD">USD</option>
+                <option value="GBP">GBP</option>
+              </select>
             </div>
           </div>
 
-          {/* Notes */}
           <div>
-            <label className="label">Notes</label>
-            <textarea
-              value={formData.notes}
-              onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+            <label className="label">Kategorie</label>
+            <select
+              value={formData.category}
+              onChange={(e) =>
+                setFormData({ ...formData, category: e.target.value as 'business' | 'private' | 'vacation' })
+              }
               className="input"
-              rows={3}
-            />
+            >
+              <option value="business">Geschäftlich</option>
+              <option value="private">Privat</option>
+              <option value="vacation">Urlaub</option>
+            </select>
           </div>
+        </div>
+
+        <div>
+          <label className="label">Tags</label>
+          <input
+            type="text"
+            value={formData.tags?.join(', ') ?? ''}
+            onChange={(e) =>
+              setFormData({
+                ...formData,
+                tags: e.target.value
+                  .split(',')
+                  .map((tag) => tag.trim())
+                  .filter(Boolean),
+              })
+            }
+            className="input"
+            placeholder="Kommagetrennt, z.B. Konferenz, Nachtflug"
+          />
+          <p className="text-xs text-gray-500 mt-1">Tags können später gefiltert und farblich markiert werden.</p>
+        </div>
+      </div>
+
+      {/* Notes */}
+      <div>
+        <label className="label">Notes</label>
+        <textarea
+          value={formData.notes}
+          onChange={(e) => setFormData({ ...formData, notes: e.target.value })}
+          className="input"
+          rows={3}
+        />
+      </div>
 
           {/* Actions */}
           <div className="flex gap-3 justify-end pt-4 border-t">

--- a/frontend/src/components/FlightList.tsx
+++ b/frontend/src/components/FlightList.tsx
@@ -85,6 +85,35 @@ export default function FlightList({
                 </div>
               </div>
 
+              <div className="flex flex-wrap items-center gap-3 mt-3 text-sm">
+                {flight.category && (
+                  <span className="px-2 py-1 rounded-full bg-indigo-100 text-indigo-800 dark:bg-indigo-900 dark:text-indigo-100">
+                    {flight.category === 'business'
+                      ? 'Geschäftlich'
+                      : flight.category === 'vacation'
+                      ? 'Urlaub'
+                      : 'Privat'}
+                  </span>
+                )}
+                {flight.ticketPrice !== undefined && (
+                  <span className="px-2 py-1 rounded-full bg-amber-100 text-amber-800 dark:bg-amber-900 dark:text-amber-100">
+                    {flight.ticketPrice.toFixed(2)} {flight.currency || 'EUR'}
+                  </span>
+                )}
+                {flight.tags && flight.tags.length > 0 && (
+                  <div className="flex flex-wrap gap-2">
+                    {flight.tags.map((tag) => (
+                      <span
+                        key={tag}
+                        className="px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200"
+                      >
+                        #{tag}
+                      </span>
+                    ))}
+                  </div>
+                )}
+              </div>
+
               {flight.aircraft && (
                 <p className="text-sm text-gray-600 dark:text-gray-400 mt-2">
                   Aircraft: {flight.aircraft}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -41,6 +41,10 @@ export interface Flight {
   terminal?: string;
   bookingReference?: string;
   ticketNumber?: string;
+  ticketPrice?: number;
+  currency?: string;
+  category?: 'business' | 'private' | 'vacation';
+  tags?: string[];
 }
 
 export interface FlightInput {
@@ -62,6 +66,10 @@ export interface FlightInput {
   terminal?: string;
   bookingReference?: string;
   ticketNumber?: string;
+  ticketPrice?: number;
+  currency?: string;
+  category?: 'business' | 'private' | 'vacation';
+  tags?: string[];
 }
 
 export interface FlightFilters {


### PR DESCRIPTION
## Summary
- extend flight schema and API to capture ticket price, currency, category, and tags
- expose new budgeting and tagging fields in the flight creation form with helpful defaults
- show saved categories, costs, and tags directly in the flight list

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921dd8448d483249152e1cfb209bf1b)