### PR TITLE
Add Aviationstack lookup for flight autofill

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,5 +9,8 @@ JWT_EXPIRES_IN=7d
 NODE_ENV=development
 PORT=8000
 
+# External APIs
+AVIATIONSTACK_API_KEY=your-aviationstack-key
+
 # CORS
 CORS_ORIGIN=http://localhost:3000

--- a/backend/src/routes/flights.ts
+++ b/backend/src/routes/flights.ts
@@ -5,11 +5,36 @@ import { createFlightSchema, updateFlightSchema, flightQuerySchema } from '../sc
 import { AppError } from '../middleware/errorHandler';
 import { calculateDistance, generateArcPoints } from '../utils/geo';
 import { checkAndUpdateAchievements } from '../utils/achievements';
+import { lookupFlightDetails } from '../services/flightLookup';
 
 const router = Router();
 
 // All routes require authentication
 router.use(authenticate);
+
+// Lookup flight details from external providers (Aviationstack)
+router.get('/lookup', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { flightNumber, date } = req.query;
+
+    if (!flightNumber || typeof flightNumber !== 'string') {
+      return res.status(400).json({ error: 'flightNumber is required' });
+    }
+
+    const lookup = await lookupFlightDetails(
+      flightNumber,
+      typeof date === 'string' ? date : undefined
+    );
+
+    if (!lookup) {
+      return res.status(404).json({ error: 'No flight data found' });
+    }
+
+    res.json(lookup);
+  } catch (error) {
+    next(error);
+  }
+});
 
 // Create flight
 router.post('/', async (req: AuthRequest, res: Response, next: NextFunction) => {

--- a/backend/src/services/flightLookup.ts
+++ b/backend/src/services/flightLookup.ts
@@ -1,0 +1,114 @@
+import { findOrCreateAirport } from './airportLookup';
+
+interface AviationStackResponse {
+  data?: AviationStackFlight[];
+  error?: { message?: string };
+}
+
+interface AviationStackFlight {
+  airline?: { name?: string; iata?: string; icao?: string };
+  flight?: { number?: string; iata?: string; icao?: string };
+  departure?: {
+    airport?: string;
+    iata?: string;
+    icao?: string;
+    scheduled?: string;
+    estimated?: string;
+  };
+  arrival?: {
+    airport?: string;
+    iata?: string;
+    icao?: string;
+    scheduled?: string;
+    estimated?: string;
+  };
+  aircraft?: { iata?: string; icao?: string; registration?: string };
+}
+
+export interface FlightLookupResult {
+  airline?: string;
+  flightNumber?: string;
+  aircraft?: string;
+  departure?: any;
+  arrival?: any;
+  departureTime?: string;
+  arrivalTime?: string;
+}
+
+/**
+ * Fetches flight details from Aviationstack and enriches airports via our DB lookups.
+ * Returns null when no API key is configured or no data is found.
+ */
+export async function lookupFlightDetails(
+  flightNumber: string,
+  date?: string
+): Promise<FlightLookupResult | null> {
+  const apiKey = process.env.AVIATIONSTACK_API_KEY;
+
+  if (!apiKey) {
+    console.warn('AVIATIONSTACK_API_KEY not set, skipping flight lookup');
+    return null;
+  }
+
+  const params = new URLSearchParams({ access_key: apiKey, limit: '1' });
+  const trimmedNumber = flightNumber.trim();
+
+  if (!trimmedNumber) {
+    return null;
+  }
+
+  // Aviationstack prefers either flight_iata or flight_icao
+  if (/^[A-Za-z]{2}\d+/.test(trimmedNumber)) {
+    params.set('flight_iata', trimmedNumber);
+  } else {
+    params.set('flight_icao', trimmedNumber);
+  }
+
+  if (date) {
+    params.set('flight_date', date);
+  }
+
+  const url = `http://api.aviationstack.com/v1/flights?${params.toString()}`;
+
+  try {
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      console.error('Aviationstack request failed', await response.text());
+      return null;
+    }
+
+    const json = (await response.json()) as AviationStackResponse;
+
+    if (json.error) {
+      console.error('Aviationstack returned error', json.error);
+      return null;
+    }
+
+    const result = json.data?.[0];
+    if (!result) {
+      return null;
+    }
+
+    const departureCode = result.departure?.iata || result.departure?.icao;
+    const arrivalCode = result.arrival?.iata || result.arrival?.icao;
+
+    const [departureAirport, arrivalAirport] = await Promise.all([
+      departureCode ? findOrCreateAirport(departureCode) : Promise.resolve(null),
+      arrivalCode ? findOrCreateAirport(arrivalCode) : Promise.resolve(null),
+    ]);
+
+    return {
+      airline: result.airline?.name,
+      flightNumber: result.flight?.iata || result.flight?.icao || trimmedNumber,
+      aircraft: result.aircraft?.icao || result.aircraft?.iata,
+      departure: departureAirport || undefined,
+      arrival: arrivalAirport || undefined,
+      departureTime: result.departure?.estimated || result.departure?.scheduled,
+      arrivalTime: result.arrival?.estimated || result.arrival?.scheduled,
+    };
+  } catch (error) {
+    console.error('Aviationstack lookup failed', error);
+    return null;
+  }
+}

--- a/frontend/src/components/AirportAutocomplete.tsx
+++ b/frontend/src/components/AirportAutocomplete.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { airportsApi, Airport } from '../lib/api';
 
 interface AirportAutocompleteProps {
-  value?: Airport;
+  value?: Airport | null;
   onChange: (airport: Airport | null) => void;
   label: string;
   placeholder?: string;

--- a/frontend/src/components/SimplifiedFlightForm.tsx
+++ b/frontend/src/components/SimplifiedFlightForm.tsx
@@ -1,9 +1,9 @@
 import { useState, useEffect } from 'react';
-import { Airport, airportsApi } from '../lib/api';
+import { Airport, airportsApi, flightsApi } from '../lib/api';
 import AirportAutocomplete from './AirportAutocomplete';
 import BoardingPassScanner from './BoardingPassScanner';
 import { BoardingPassData, getAirlineName } from '../lib/bcbpParser';
-import type { FlightInput } from '../types';
+import type { FlightInput, FlightLookupResult } from '../types';
 
 interface SimplifiedFlightFormProps {
   onSubmit: (flight: FlightInput) => Promise<void>;
@@ -13,6 +13,7 @@ interface SimplifiedFlightFormProps {
 export default function SimplifiedFlightForm({ onSubmit, onCancel }: SimplifiedFlightFormProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
+  const [autoFillMessage, setAutoFillMessage] = useState('');
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [showScanner, setShowScanner] = useState(false);
 
@@ -65,6 +66,68 @@ export default function SimplifiedFlightForm({ onSubmit, onCancel }: SimplifiedF
     }
   }, [departureDate]);
 
+  const applyLookupData = (lookup: FlightLookupResult) => {
+    if (!lookup) return;
+
+    if (lookup.airline) setAirline(lookup.airline);
+    if (lookup.flightNumber) setFlightNumber(lookup.flightNumber);
+    if (lookup.aircraft) setAircraft(prev => prev || lookup.aircraft || '');
+
+    if (lookup.departure) setDeparture(lookup.departure);
+    if (lookup.arrival) setArrival(lookup.arrival);
+
+    const updateDateTime = (
+      isoString: string | undefined,
+      setDate: (val: string) => void,
+      setTime: (val: string) => void
+    ) => {
+      if (!isoString) return;
+      const parsed = new Date(isoString);
+      if (Number.isNaN(parsed.getTime())) return;
+
+      setDate(parsed.toISOString().split('T')[0]);
+      setTime(parsed.toTimeString().slice(0, 5));
+    };
+
+    updateDateTime(lookup.departureTime, setDepartureDate, setDepartureTime);
+    updateDateTime(lookup.arrivalTime, setArrivalDate, setArrivalTime);
+  };
+
+  useEffect(() => {
+    const normalizedFlightNumber = flightNumber.trim();
+    if (!normalizedFlightNumber) {
+      setAutoFillMessage('');
+      return;
+    }
+
+    let cancelled = false;
+    const timer = setTimeout(async () => {
+      setAutoFillMessage('🔄 Suche Fluginfos (Aviationstack)...');
+      try {
+        const lookup = await flightsApi.lookup({
+          flightNumber: normalizedFlightNumber,
+          date: departureDate || undefined,
+        });
+
+        if (cancelled || !lookup) return;
+
+        applyLookupData(lookup);
+        setShowAdvanced(true);
+        setAutoFillMessage('✈️ Daten automatisch ergänzt');
+      } catch (lookupError) {
+        if (!cancelled) {
+          console.warn('Flight lookup failed', lookupError);
+          setAutoFillMessage('');
+        }
+      }
+    }, 600);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+    };
+  }, [flightNumber, departureDate]);
+
   const handleBoardingPassScan = async (bcbpData: BoardingPassData) => {
     setShowScanner(false);
     setError('');
@@ -88,7 +151,7 @@ export default function SimplifiedFlightForm({ onSubmit, onCancel }: SimplifiedF
         depAirport = {
           id: 0,
           iata: bcbpData.departureAirport,
-          icao: null,
+          icao: undefined,
           name: bcbpData.departureAirport,
           city: null,
           country: null,
@@ -100,7 +163,7 @@ export default function SimplifiedFlightForm({ onSubmit, onCancel }: SimplifiedF
         arrAirport = {
           id: 0,
           iata: bcbpData.arrivalAirport,
-          icao: null,
+          icao: undefined,
           name: bcbpData.arrivalAirport,
           city: null,
           country: null,
@@ -318,6 +381,9 @@ export default function SimplifiedFlightForm({ onSubmit, onCancel }: SimplifiedF
                       className="input"
                       placeholder="e.g., LH123"
                     />
+                    {autoFillMessage && (
+                      <p className="text-xs text-blue-600 mt-1">{autoFillMessage}</p>
+                    )}
                   </div>
                 </div>
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -9,7 +9,8 @@ import type {
   GeoJSONFeatureCollection,
   AchievementsResponse,
   UserAchievement,
-  LeaderboardEntry
+  LeaderboardEntry,
+  FlightLookupResult
 } from '../types';
 
 const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
@@ -87,6 +88,11 @@ export const flightsApi = {
   delete: async (id: string) => {
     await api.delete(`/flights/${id}`);
   },
+
+  lookup: async (params: { flightNumber: string; date?: string }) => {
+    const { data } = await api.get<FlightLookupResult>('/flights/lookup', { params });
+    return data;
+  },
 };
 
 // Stats API
@@ -106,7 +112,7 @@ export const statsApi = {
 
 // Airport API
 export interface Airport {
-  id: number;
+  id?: number;
   iata?: string;
   icao?: string;
   name: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -4,11 +4,16 @@ export interface User {
 }
 
 export interface Airport {
+  id?: number;
   icao?: string;
   iata?: string;
   name?: string;
+  city?: string | null;
+  country?: string | null;
   lat: number;
   lon: number;
+  altitude?: number | null;
+  timezone?: string | null;
 }
 
 export interface Flight {
@@ -48,8 +53,8 @@ export interface Flight {
 }
 
 export interface FlightInput {
-  airline: string;
-  flightNumber: string;
+  airline?: string;
+  flightNumber?: string;
   callsign?: string;
   aircraft?: string;
   departure: Airport;
@@ -70,6 +75,16 @@ export interface FlightInput {
   currency?: string;
   category?: 'business' | 'private' | 'vacation';
   tags?: string[];
+}
+
+export interface FlightLookupResult {
+  airline?: string;
+  flightNumber?: string;
+  aircraft?: string;
+  departure?: Airport;
+  arrival?: Airport;
+  departureTime?: string;
+  arrivalTime?: string;
 }
 
 export interface FlightFilters {


### PR DESCRIPTION
## Summary
- add Aviationstack-backed flight lookup service and secure API endpoint to enrich airport data automatically
- expose flight lookup to the frontend and enhance the simplified flight form with autofill for manual entry and boarding pass scans
- document the new API key and allow airport autocomplete to handle missing IDs from external sources

## Testing
- npm run build (backend) *(fails: pre-existing TypeScript errors in unrelated files)*
- npm run build (frontend) *(fails: pre-existing TypeScript errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922bffbfb808324a7e2be467d5d972e)