### PR TITLE
feat: Phase 1 — Email als primärer Eingabetyp + Community Template System

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,7 @@
         "archiver": "^7.0.1",
         "axios": "^1.13.5",
         "bcrypt": "^5.1.1",
+        "cheerio": "^1.2.0",
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "csv-parse": "^6.1.0",
@@ -3123,6 +3124,48 @@
         "node": "*"
       }
     },
+    "node_modules/cheerio": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+      "license": "MIT",
+      "dependencies": {
+        "cheerio-select": "^2.1.0",
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "encoding-sniffer": "^0.2.1",
+        "htmlparser2": "^10.1.0",
+        "parse5": "^7.3.0",
+        "parse5-htmlparser2-tree-adapter": "^7.1.0",
+        "parse5-parser-stream": "^7.1.2",
+        "undici": "^7.19.0",
+        "whatwg-mimetype": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+      }
+    },
+    "node_modules/cheerio-select": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+      "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-select": "^5.1.0",
+        "css-what": "^6.1.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
     "node_modules/chownr": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
@@ -3856,6 +3899,31 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/encoding-sniffer": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "^0.6.3",
+        "whatwg-encoding": "^3.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+      }
+    },
+    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/end-of-stream": {
@@ -4733,6 +4801,37 @@
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/htmlparser2": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/http-errors": {
       "version": "2.0.0",
@@ -6663,6 +6762,55 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+      "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+      "license": "MIT",
+      "dependencies": {
+        "domhandler": "^5.0.3",
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5-parser-stream": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+      "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^7.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -8227,6 +8375,15 @@
         "node": ">=0.8.0"
       }
     },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
@@ -8461,6 +8618,40 @@
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -42,6 +42,7 @@
     "archiver": "^7.0.1",
     "axios": "^1.13.5",
     "bcrypt": "^5.1.1",
+    "cheerio": "^1.2.0",
     "cookie-parser": "^1.4.7",
     "cors": "^2.8.5",
     "csv-parse": "^6.1.0",

--- a/backend/prisma/migrations/20260311000000_add_phase1_email_fields/migration.sql
+++ b/backend/prisma/migrations/20260311000000_add_phase1_email_fields/migration.sql
@@ -1,0 +1,7 @@
+-- AlterTable: Add Phase 1 email template parsing fields to flights
+ALTER TABLE "flights" ADD COLUMN     "baggage_allowance" TEXT,
+ADD COLUMN     "booking_class_letter" TEXT,
+ADD COLUMN     "co_passengers" TEXT[] DEFAULT ARRAY[]::TEXT[],
+ADD COLUMN     "frequent_flyer_number" TEXT,
+ADD COLUMN     "parser_confidence" INTEGER,
+ADD COLUMN     "parser_template" TEXT;

--- a/backend/prisma/migrations/20260311100000_add_parse_training_log/migration.sql
+++ b/backend/prisma/migrations/20260311100000_add_parse_training_log/migration.sql
@@ -1,0 +1,27 @@
+-- CreateTable
+CREATE TABLE "parse_training_logs" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "airline" TEXT,
+    "template_used" TEXT,
+    "template_hit" BOOLEAN NOT NULL,
+    "confidence" INTEGER,
+    "field_count" INTEGER NOT NULL,
+    "missing_fields" TEXT[] NOT NULL DEFAULT ARRAY[]::TEXT[],
+    "parser_provider" TEXT NOT NULL,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "parse_training_logs_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "parse_training_logs_user_id_idx" ON "parse_training_logs"("user_id");
+
+-- CreateIndex
+CREATE INDEX "parse_training_logs_template_hit_idx" ON "parse_training_logs"("template_hit");
+
+-- CreateIndex
+CREATE INDEX "parse_training_logs_airline_idx" ON "parse_training_logs"("airline");
+
+-- AddForeignKey
+ALTER TABLE "parse_training_logs" ADD CONSTRAINT "parse_training_logs_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -32,6 +32,7 @@ model User {
   trainingData          TrainingData[]
   pendingFlightUpdates  PendingFlightUpdate[]
   pendingUpdateStats    PendingUpdateStatistics?
+  parseLogs             ParseTrainingLog[]
 
   @@map("users")
 }
@@ -464,6 +465,26 @@ model SmtpConfig {
   updatedAt DateTime @updatedAt @map("updated_at")
 
   @@map("smtp_config")
+}
+
+model ParseTrainingLog {
+  id             String   @id @default(uuid())
+  userId         String   @map("user_id")
+  airline        String?
+  templateUsed   String?  @map("template_used")
+  templateHit    Boolean  @map("template_hit")
+  confidence     Int?
+  fieldCount     Int      @map("field_count")
+  missingFields  String[] @map("missing_fields")
+  parserProvider String   @map("parser_provider")
+  createdAt      DateTime @default(now()) @map("created_at")
+
+  user           User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([templateHit])
+  @@index([airline])
+  @@map("parse_training_logs")
 }
 
 model PendingUpdateStatistics {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -106,6 +106,14 @@ model Flight {
   lastModifiedBy   String?  @map("last_modified_by") // 'user', 'auto_update', 'historical_enrichment', 'api'
   enrichmentHistory Json?   @map("enrichment_history") // Array of enrichment events [{type, timestamp, confidence?, source?}]
 
+  // Phase 1: Email Template Parsing
+  baggageAllowance    String?  @map("baggage_allowance")
+  frequentFlyerNumber String?  @map("frequent_flyer_number")
+  bookingClassLetter  String?  @map("booking_class_letter")  // e.g. "Y", "C", "J", "F"
+  coPassengers        String[] @default([]) @map("co_passengers")
+  parserTemplate      String?  @map("parser_template")       // e.g. "LH" or null
+  parserConfidence    Int?     @map("parser_confidence")     // 0–100
+
   user              User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   pendingUpdates    PendingFlightUpdate[]
 

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -91,7 +91,7 @@ model Flight {
   fees             Float?   @map("fees")
   category         String?  @default("private") @map("category") // business, private, vacation
   tags             String[] @default([]) @map("tags")
-  companions       String[] @default([]) @map("companions")
+  companions       String[] @default([]) @map("companions")  // User-defined travel group (set manually, vs. coPassengers = auto-parsed from email)
   receiptUrl       String?  @map("receipt_url")
   ticketPrice      Float?   @map("ticket_price")
   createdAt        DateTime @default(now()) @map("created_at")
@@ -110,7 +110,7 @@ model Flight {
   baggageAllowance    String?  @map("baggage_allowance")
   frequentFlyerNumber String?  @map("frequent_flyer_number")
   bookingClassLetter  String?  @map("booking_class_letter")  // e.g. "Y", "C", "J", "F"
-  coPassengers        String[] @default([]) @map("co_passengers")
+  coPassengers        String[] @default([]) @map("co_passengers")  // Names parsed from booking email (vs. companions = user-defined travel group)
   parserTemplate      String?  @map("parser_template")       // e.g. "LH" or null
   parserConfidence    Int?     @map("parser_confidence")     // 0–100
 

--- a/backend/src/__tests__/templates/detector.test.ts
+++ b/backend/src/__tests__/templates/detector.test.ts
@@ -1,0 +1,19 @@
+import { detectAirline } from "../../services/parsers/templates/detector";
+
+describe("detectAirline", () => {
+  it("detects Lufthansa by from-address", () => {
+    expect(detectAirline("noreply@lufthansa.com", "Buchungsbestätigung", "")).toBe("LH");
+  });
+
+  it("detects Ryanair by from-address", () => {
+    expect(detectAirline("noreply@ryanair.com", "Your booking", "")).toBe("FR");
+  });
+
+  it("detects easyJet by subject pattern", () => {
+    expect(detectAirline("noreply@easyjet.com", "Your easyJet booking confirmation", "")).toBe("U2");
+  });
+
+  it("returns null for unknown airline", () => {
+    expect(detectAirline("noreply@unknown-airline.xx", "Booking", "")).toBeNull();
+  });
+});

--- a/backend/src/__tests__/templates/detector.test.ts
+++ b/backend/src/__tests__/templates/detector.test.ts
@@ -10,7 +10,8 @@ describe("detectAirline", () => {
   });
 
   it("detects easyJet by subject pattern", () => {
-    expect(detectAirline("noreply@easyjet.com", "Your easyJet booking confirmation", "")).toBe("U2");
+    // Use an email address that doesn't match any fromDomain rule
+    expect(detectAirline("", "Your easyJet booking confirmation", "")).toBe("U2");
   });
 
   it("returns null for unknown airline", () => {

--- a/backend/src/__tests__/templates/engine.test.ts
+++ b/backend/src/__tests__/templates/engine.test.ts
@@ -1,0 +1,58 @@
+import { applyTemplate } from "../../services/parsers/templates/engine";
+import type { AirlineTemplate } from "../../services/parsers/templates/types";
+
+const mockTemplate: AirlineTemplate = {
+  airline: "TestAir",
+  iata: "TA",
+  version: "2024-01",
+  from: ["@testair.com"],
+  subject: [],
+  selectors: {
+    flightNumber: ".flight-number",
+    departureCode: ".dep-code",
+    pnr: ".pnr",
+  },
+  transforms: {},
+  testCases: [],
+};
+
+const mockHtml = `
+  <html><body>
+    <span class="flight-number">TA1234</span>
+    <span class="dep-code">FRA</span>
+    <span class="pnr">ABC123</span>
+  </body></html>
+`;
+
+describe("applyTemplate", () => {
+  it("extracts fields using CSS selectors", () => {
+    const result = applyTemplate(mockTemplate, "", mockHtml);
+    expect(result.flightNumber).toBe("TA1234");
+    expect(result.departureCode).toBe("FRA");
+    expect(result.bookingReference).toBe("ABC123");
+    expect(result.parserTemplate).toBe("TA");
+  });
+
+  it("applies transform functions to values", () => {
+    const templateWithTransform: AirlineTemplate = {
+      ...mockTemplate,
+      transforms: { flightNumber: "value => value.toLowerCase()" },
+    };
+    const result = applyTemplate(templateWithTransform, "", mockHtml);
+    expect(result.flightNumber).toBe("ta1234");
+  });
+
+  it("returns undefined for fields with no matching selector", () => {
+    const textOnlyTemplate: AirlineTemplate = {
+      ...mockTemplate,
+      selectors: { flightNumber: ".nonexistent" },
+    };
+    const result = applyTemplate(textOnlyTemplate, "Flight TA1234", "");
+    expect(result.flightNumber).toBeUndefined();
+  });
+
+  it("populates missing array for critical fields not found", () => {
+    const result = applyTemplate(mockTemplate, "", "");
+    expect(result.missing).toContain("flightNumber");
+  });
+});

--- a/backend/src/__tests__/templates/engine.test.ts
+++ b/backend/src/__tests__/templates/engine.test.ts
@@ -36,7 +36,7 @@ describe("applyTemplate", () => {
   it("applies transform functions to values", () => {
     const templateWithTransform: AirlineTemplate = {
       ...mockTemplate,
-      transforms: { flightNumber: "value => value.toLowerCase()" },
+      transforms: { flightNumber: "lowercase" },
     };
     const result = applyTemplate(templateWithTransform, "", mockHtml);
     expect(result.flightNumber).toBe("ta1234");

--- a/backend/src/__tests__/templates/types.test.ts
+++ b/backend/src/__tests__/templates/types.test.ts
@@ -1,0 +1,21 @@
+import { isValidAirlineTemplate } from "../../services/parsers/templates/types";
+
+describe("isValidAirlineTemplate", () => {
+  it("accepts a minimal valid template", () => {
+    const template = {
+      airline: "Lufthansa",
+      iata: "LH",
+      version: "2024-03",
+      from: ["@lufthansa.com"],
+      subject: ["Buchungsbestätigung"],
+      selectors: { flightNumber: ".flight-no" },
+      transforms: {},
+      testCases: [],
+    };
+    expect(isValidAirlineTemplate(template)).toBe(true);
+  });
+
+  it("rejects template missing required fields", () => {
+    expect(isValidAirlineTemplate({ airline: "LH" })).toBe(false);
+  });
+});

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -23,6 +23,7 @@ import adminRoutes from './routes/admin';
 import trainingRoutes from './routes/training';
 import backupRoutes from './routes/backup';
 import pendingUpdatesRoutes from './routes/pendingUpdates';
+import templateStatusRoutes from './routes/templateStatus';
 import { errorHandler } from './middleware/errorHandler';
 import { requestLoggerMiddleware } from './middleware/requestLogger';
 import { prisma } from './db';
@@ -174,6 +175,7 @@ app.use('/api/v1/parser-feedback', parserFeedbackRoutes);
 app.use('/api/v1/training', trainingRoutes);
 app.use('/api/v1/backup', backupRoutes);
 app.use('/api/v1/pending-updates', pendingUpdatesRoutes);
+app.use('/api/v1/template-status', templateStatusRoutes);
 
 // Error handling
 app.use(errorHandler);

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -28,6 +28,7 @@ import { requestLoggerMiddleware } from './middleware/requestLogger';
 import { prisma } from './db';
 import logger from './utils/logger';
 import { DATABASE_URL } from './utils/database';
+import { templateRegistry } from './services/parsers/templates/registry';
 
 // Load environment variables
 dotenv.config();
@@ -280,6 +281,23 @@ if (process.env.NODE_ENV !== 'test') {
       logger.warn({
         operation: 'server_start_reminder_scheduler_error',
         message: 'Failed to start flight reminder scheduler',
+        error: {
+          message: error instanceof Error ? error.message : 'Unknown error',
+        },
+      });
+    }
+
+    // Initialize airline template registry
+    try {
+      await templateRegistry.initialize();
+      logger.info({
+        operation: 'server_start_template_registry',
+        message: 'Airline template registry initialized',
+      });
+    } catch (error) {
+      logger.warn({
+        operation: 'server_start_template_registry_error',
+        message: 'Failed to initialize airline template registry',
         error: {
           message: error instanceof Error ? error.message : 'Unknown error',
         },

--- a/backend/src/routes/emailParse.ts
+++ b/backend/src/routes/emailParse.ts
@@ -79,7 +79,10 @@ router.post('/parse-email', authenticate, async (req: AuthRequest, res: Response
       ).catch(err => logger.warn({ error: err }, '[Email Parse] Failed to collect feedback'));
     }
 
-    res.json(result);
+    res.json({
+      ...result,
+      airlineNotice: result.flights[0]?.airlineNotice ?? null,
+    });
   } catch (error) {
     if (error instanceof z.ZodError) {
       logger.warn({ errors: error.errors }, '[Email Parse] Validation error');
@@ -197,6 +200,7 @@ router.post(
         subject: extracted.subject,
         text: extracted.text.substring(0, 1000), // Truncate for feedback (first 1000 chars)
         html: extracted.html ? extracted.html.substring(0, 1000) : undefined, // Truncate for feedback
+        airlineNotice: result.flights[0]?.airlineNotice ?? null,
       });
     } catch (error) {
       // Cleanup: Delete temporary file on error

--- a/backend/src/routes/templateStatus.ts
+++ b/backend/src/routes/templateStatus.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import type { Response } from "express";
+import { templateRegistry } from "../services/parsers/templates/registry";
+import { authenticate, AuthRequest } from "../middleware/auth";
+
+const router = Router();
+
+router.get("/", authenticate, (_req: AuthRequest, res: Response): void => {
+  res.json({
+    templates: templateRegistry.getStatus(),
+    total: templateRegistry.getAll().length,
+    githubRepo: "https://github.com/travstats-community/airline-templates",
+  });
+});
+
+export default router;

--- a/backend/src/services/bookingParser.ts
+++ b/backend/src/services/bookingParser.ts
@@ -23,6 +23,14 @@ export interface ParsedBooking {
   boardingGroup?: string;         // e.g., "1", "A", "Zone 3"
   taxes?: string;                 // Tax amount (separate from total price)
   fees?: string;                  // Fees amount (separate from total price)
+  // Phase 1: New fields
+  baggageAllowance?: string;      // e.g. "1x23kg", "20kg included"
+  frequentFlyerNumber?: string;   // e.g. "LH-123456789"
+  bookingClassLetter?: string;    // IATA booking class, e.g. "Y", "M", "C", "J", "F"
+  coPassengers?: string[];        // e.g. ["Max Mustermann", "Erika Musterfrau"]
+  parserTemplate?: string;        // Which template was used, e.g. "LH"
+  parserConfidence?: number;      // 0–100
+  airlineNotice?: string;         // User-facing notice if no template found
   missing: string[];
 }
 

--- a/backend/src/services/bookingParser.ts
+++ b/backend/src/services/bookingParser.ts
@@ -30,7 +30,7 @@ export interface ParsedBooking {
   coPassengers?: string[];        // e.g. ["Max Mustermann", "Erika Musterfrau"]
   parserTemplate?: string;        // Which template was used, e.g. "LH"
   parserConfidence?: number;      // 0–100
-  airlineNotice?: string;         // User-facing notice if no template found
+  airlineNotice?: string;         // Transient: not persisted to DB, UI-only notice when no template found
   missing: string[];
 }
 

--- a/backend/src/services/parsers/factory.ts
+++ b/backend/src/services/parsers/factory.ts
@@ -26,6 +26,7 @@ import { getOllamaTextParser } from './text/ollamaTextParser';
 import { getOpenAITextParser } from './text/openaiTextParser';
 import { getClaudeTextParser } from './text/claudeTextParser';
 import { getRegexParser } from './text/regexParser';
+import { TemplateParser } from './text/templateParser';
 
 /**
  * Parser Factory
@@ -148,7 +149,7 @@ export async function getParserConfig(
 ): Promise<ParserConfig> {
   // Import here to avoid circular dependency
   const { selectModelForParsing } = await import('../modelManager');
-  
+
   // Select models based on user settings and availability
   const selectedEmailModel = await selectModelForParsing('email', userId);
   const selectedVisionModel = await selectModelForParsing('vision', userId);
@@ -174,6 +175,7 @@ export async function getParserConfig(
     claudeApiKey: userSettings?.claudeApiKey || adminSettings?.globalClaudeApiKey || process.env.CLAUDE_API_KEY,
     claudeModel: process.env.CLAUDE_MODEL,
     claudeVisionModel: process.env.CLAUDE_VISION_MODEL,
+    userId,
   };
 }
 
@@ -611,12 +613,12 @@ export async function parseBoardingPass(
       } else {
         logger.info(`[Parser Factory] Attempting vision parse with: ${provider}`);
       }
-      
+
       const flight = await parser.parseImage(imageBase64, apiKey);
       const parseDuration = Date.now() - parseStartTime;
 
       const fallbackUsed = config.visionProvider !== 'auto' && config.visionProvider !== provider;
-      
+
       if (shouldLog) {
         visionLog.info({
           operation: 'vision_parse_success',
@@ -666,7 +668,7 @@ export async function parseBoardingPass(
             const tesseractStartTime = Date.now();
             const tesseractFlight = await tesseractParser.parseImage(imageBase64);
             const tesseractDuration = Date.now() - tesseractStartTime;
-            
+
             if (shouldLog) {
               visionLog.info({
                 operation: 'tesseract_fallback_completed',
@@ -808,6 +810,25 @@ export async function parseEmail(
     });
   }
 
+  // Template-Parser first (before LLM chain)
+  const templateParser = new TemplateParser();
+  const templateAvail = await templateParser.checkAvailability();
+  if (templateAvail.available) {
+    const templateResults = await templateParser.parseEmail(subject, text, html, config.userId);
+    if (templateResults.length > 0 && (templateResults[0].parserConfidence ?? 0) >= 30) {
+      logger.info(
+        { confidence: templateResults[0].parserConfidence, parserTemplate: templateResults[0].parserTemplate },
+        '[Parser Factory] Template parser matched with sufficient confidence, skipping LLM chain'
+      );
+      return {
+        flights: templateResults,
+        provider: 'regex' as const, // "template" is not in TextProvider union — map to nearest
+        fallbackUsed: false,
+      };
+    }
+  }
+  // End template block — LLM chain follows
+
   // Build the provider chain: preferred (if not auto) + fallbacks
   const providerChain: TextProvider[] =
     config.textProvider !== 'auto'
@@ -855,7 +876,7 @@ export async function parseEmail(
       } else {
         logger.info(`[Parser Factory] Attempting email parse with: ${provider}`);
       }
-      
+
       const flights = await parser.parseEmail(subject, text, html, apiKey);
       const parseDuration = Date.now() - parseStartTime;
 
@@ -931,7 +952,7 @@ export async function parseEmail(
             } else {
               logger.info(`[Parser Factory] Attempting LLM quality fallback with: ${llmProvider}`);
             }
-            
+
             const llmStartTime = Date.now();
             const llmFlights = await llmParser.parseEmail(subject, text, html, llmApiKey);
             const llmDuration = Date.now() - llmStartTime;
@@ -1010,7 +1031,7 @@ export async function parseEmail(
 
       const finalQuality = calculateParserQuality(finalFlights);
       const totalDuration = Date.now() - startTime;
-      
+
       if (shouldLog) {
         log.info({
           operation: 'parse_email_complete',

--- a/backend/src/services/parsers/templates/airlines/EW.json
+++ b/backend/src/services/parsers/templates/airlines/EW.json
@@ -1,0 +1,22 @@
+{
+  "airline": "Eurowings",
+  "iata": "EW",
+  "version": "2024-03",
+  "from": ["@eurowings.com", "@newsletter.eurowings.com"],
+  "subject": ["Buchungsbestätigung", "Eurowings booking"],
+  "selectors": {
+    "flightNumber": ".flight-no, .flightnumber",
+    "pnr": ".booking-code, .pnr",
+    "departureCode": ".departure-code",
+    "arrivalCode": ".arrival-code",
+    "departureTime": ".dep-datetime",
+    "arrivalTime": ".arr-datetime",
+    "seat": ".seat-number",
+    "seatClass": ".fare-class",
+    "price": ".total-price",
+    "currency": ".currency",
+    "baggage": ".baggage-info"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/FR.json
+++ b/backend/src/services/parsers/templates/airlines/FR.json
@@ -1,0 +1,22 @@
+{
+  "airline": "Ryanair",
+  "iata": "FR",
+  "version": "2024-03",
+  "from": ["@ryanair.com", "@info.ryanair.com"],
+  "subject": ["Your booking confirmation", "Ihre Buchungsbestätigung"],
+  "selectors": {
+    "flightNumber": ".flight-num, td.flight-number",
+    "pnr": ".booking-reference, .pnr",
+    "departureCode": ".origin-code",
+    "arrivalCode": ".destination-code",
+    "departureTime": ".departure-datetime",
+    "arrivalTime": ".arrival-datetime",
+    "seat": ".seat",
+    "price": ".grand-total",
+    "currency": ".currency-symbol",
+    "baggage": ".baggage-details",
+    "ticketNumber": ".ticket-no"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/LH.json
+++ b/backend/src/services/parsers/templates/airlines/LH.json
@@ -1,0 +1,27 @@
+{
+  "airline": "Lufthansa",
+  "iata": "LH",
+  "version": "2024-03",
+  "from": ["@lufthansa.com", "@miles-and-more.com"],
+  "subject": ["Buchungsbestätigung", "Booking Confirmation", "Ihre Buchung"],
+  "selectors": {
+    "flightNumber": "td.flightno, .flight-number, [data-flight-number]",
+    "pnr": ".booking-code, .pnr, [data-pnr], td.pnr",
+    "departureCode": ".dep-airport-code, [data-dep-iata]",
+    "arrivalCode": ".arr-airport-code, [data-arr-iata]",
+    "departureTime": "[data-dep-datetime], .departure-time",
+    "arrivalTime": "[data-arr-datetime], .arrival-time",
+    "seat": ".seat-number, [data-seat]",
+    "seatClass": ".cabin-class, .travel-class",
+    "price": ".total-price, [data-total-price]",
+    "currency": ".currency",
+    "taxes": ".taxes-amount",
+    "fees": ".fees-amount",
+    "baggage": ".baggage-info, .gepäck",
+    "frequentFlyer": ".miles-more-number, .ffn",
+    "ticketNumber": ".ticket-number, [data-ticket]",
+    "bookingClassLetter": ".booking-class, [data-booking-class]"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/LX.json
+++ b/backend/src/services/parsers/templates/airlines/LX.json
@@ -1,0 +1,26 @@
+{
+  "airline": "Swiss",
+  "iata": "LX",
+  "version": "2024-03",
+  "from": ["@swiss.com", "@newsletter.swiss.com"],
+  "subject": ["Buchungsbestätigung", "Your SWISS booking confirmation"],
+  "selectors": {
+    "flightNumber": ".flight-number, [data-flight]",
+    "pnr": ".booking-code, .pnr",
+    "departureCode": ".dep-iata, [data-dep-iata]",
+    "arrivalCode": ".arr-iata, [data-arr-iata]",
+    "departureTime": "[data-dep-datetime]",
+    "arrivalTime": "[data-arr-datetime]",
+    "seat": ".seat-info",
+    "seatClass": ".travel-class",
+    "price": ".total-price",
+    "currency": ".currency",
+    "taxes": ".taxes",
+    "baggage": ".baggage-info",
+    "frequentFlyer": ".senator-number, .ffn",
+    "ticketNumber": ".ticket-number",
+    "bookingClassLetter": ".booking-class"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/OS.json
+++ b/backend/src/services/parsers/templates/airlines/OS.json
@@ -1,0 +1,23 @@
+{
+  "airline": "Austrian Airlines",
+  "iata": "OS",
+  "version": "2024-03",
+  "from": ["@austrian.com", "@newsletter.austrian.com"],
+  "subject": ["Buchungsbestätigung", "Austrian booking confirmation"],
+  "selectors": {
+    "flightNumber": ".flight-number, td.flight",
+    "pnr": ".booking-reference, .pnr",
+    "departureCode": ".dep-airport",
+    "arrivalCode": ".arr-airport",
+    "departureTime": ".dep-time",
+    "arrivalTime": ".arr-time",
+    "seat": ".seat",
+    "seatClass": ".class",
+    "price": ".total",
+    "currency": ".currency",
+    "baggage": ".baggage",
+    "frequentFlyer": ".miles-more, .ffn"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/SN.json
+++ b/backend/src/services/parsers/templates/airlines/SN.json
@@ -1,0 +1,23 @@
+{
+  "airline": "Brussels Airlines",
+  "iata": "SN",
+  "version": "2024-03",
+  "from": ["@brusselsairlines.com"],
+  "subject": ["Booking confirmation", "Ihre Buchungsbestätigung"],
+  "selectors": {
+    "flightNumber": ".flight-number",
+    "pnr": ".booking-code",
+    "departureCode": ".dep-airport",
+    "arrivalCode": ".arr-airport",
+    "departureTime": ".dep-time",
+    "arrivalTime": ".arr-time",
+    "seat": ".seat",
+    "seatClass": ".cabin",
+    "price": ".total-price",
+    "currency": ".currency",
+    "baggage": ".baggage",
+    "frequentFlyer": ".miles-more"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/U2.json
+++ b/backend/src/services/parsers/templates/airlines/U2.json
@@ -1,0 +1,23 @@
+{
+  "airline": "easyJet",
+  "iata": "U2",
+  "version": "2024-03",
+  "from": ["@easyjet.com", "@email.easyjet.com"],
+  "subject": ["easyJet booking confirmation", "Your easyJet booking"],
+  "selectors": {
+    "flightNumber": ".flight-number, td.flightno",
+    "pnr": ".booking-reference, .pnr-code",
+    "departureCode": ".origin-airport-code",
+    "arrivalCode": ".destination-airport-code",
+    "departureTime": ".departure-time, [data-departure]",
+    "arrivalTime": ".arrival-time, [data-arrival]",
+    "seat": ".seat-number",
+    "seatClass": ".cabin-class",
+    "price": ".total-amount, .grand-total",
+    "currency": ".currency",
+    "baggage": ".baggage-allowance, .hold-bag",
+    "ticketNumber": ".booking-ref"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/airlines/W6.json
+++ b/backend/src/services/parsers/templates/airlines/W6.json
@@ -1,0 +1,22 @@
+{
+  "airline": "Wizz Air",
+  "iata": "W6",
+  "version": "2024-03",
+  "from": ["@wizzair.com", "@info.wizzair.com"],
+  "subject": ["Booking confirmation", "Buchungsbestätigung"],
+  "selectors": {
+    "flightNumber": ".flight-number",
+    "pnr": ".booking-reference",
+    "departureCode": ".origin",
+    "arrivalCode": ".destination",
+    "departureTime": ".departure",
+    "arrivalTime": ".arrival",
+    "seat": ".seat",
+    "seatClass": ".fare-type",
+    "price": ".amount",
+    "currency": ".currency",
+    "baggage": ".baggage"
+  },
+  "transforms": {},
+  "testCases": []
+}

--- a/backend/src/services/parsers/templates/detector.ts
+++ b/backend/src/services/parsers/templates/detector.ts
@@ -62,7 +62,11 @@ export function detectAirline(
   htmlContent: string
 ): string | null {
   for (const rule of DETECTION_RULES) {
-    if (rule.fromDomains.some((domain) => fromAddress.toLowerCase().includes(domain))) {
+    const senderDomain = fromAddress.toLowerCase().split("@")[1] ?? "";
+    if (rule.fromDomains.some((d) => {
+      const ruleDomain = d.replace("@", "");
+      return senderDomain === ruleDomain || senderDomain.endsWith("." + ruleDomain);
+    })) {
       return rule.iata;
     }
     if (rule.subjectPatterns.some((pattern) => pattern.test(subject))) {

--- a/backend/src/services/parsers/templates/detector.ts
+++ b/backend/src/services/parsers/templates/detector.ts
@@ -1,0 +1,76 @@
+interface DetectionRule {
+  iata: string;
+  fromDomains: string[];
+  subjectPatterns: RegExp[];
+  htmlFingerprints: string[];
+}
+
+const DETECTION_RULES: DetectionRule[] = [
+  {
+    iata: "LH",
+    fromDomains: ["@lufthansa.com", "@miles-and-more.com"],
+    subjectPatterns: [/buchungsbest.?tigung/i, /lufthansa.*booking confirmation/i, /ihre buchung/i],
+    htmlFingerprints: ["lufthansa.com", "miles-and-more.com"],
+  },
+  {
+    iata: "LX",
+    fromDomains: ["@swiss.com", "@newsletter.swiss.com"],
+    subjectPatterns: [/buchungsbest.?tigung/i, /your swiss booking/i],
+    htmlFingerprints: ["swiss.com"],
+  },
+  {
+    iata: "OS",
+    fromDomains: ["@austrian.com", "@newsletter.austrian.com"],
+    subjectPatterns: [/austrian booking/i, /ihre buchung bei austrian/i],
+    htmlFingerprints: ["austrian.com"],
+  },
+  {
+    iata: "FR",
+    fromDomains: ["@ryanair.com", "@info.ryanair.com"],
+    subjectPatterns: [/ryanair.*booking/i, /your booking confirmation/i],
+    htmlFingerprints: ["ryanair.com"],
+  },
+  {
+    iata: "U2",
+    fromDomains: ["@easyjet.com", "@email.easyjet.com"],
+    subjectPatterns: [/easyjet.*confirmation/i, /your easyjet booking/i],
+    htmlFingerprints: ["easyjet.com"],
+  },
+  {
+    iata: "EW",
+    fromDomains: ["@eurowings.com", "@newsletter.eurowings.com"],
+    subjectPatterns: [/eurowings.*buchung/i, /eurowings.*booking/i],
+    htmlFingerprints: ["eurowings.com"],
+  },
+  {
+    iata: "W6",
+    fromDomains: ["@wizzair.com", "@info.wizzair.com"],
+    subjectPatterns: [/wizz air.*booking/i, /buchungsbest.?tigung.*wizz/i],
+    htmlFingerprints: ["wizzair.com"],
+  },
+  {
+    iata: "SN",
+    fromDomains: ["@brusselsairlines.com"],
+    subjectPatterns: [/brussels airlines.*booking/i],
+    htmlFingerprints: ["brusselsairlines.com"],
+  },
+];
+
+export function detectAirline(
+  fromAddress: string,
+  subject: string,
+  htmlContent: string
+): string | null {
+  for (const rule of DETECTION_RULES) {
+    if (rule.fromDomains.some((domain) => fromAddress.toLowerCase().includes(domain))) {
+      return rule.iata;
+    }
+    if (rule.subjectPatterns.some((pattern) => pattern.test(subject))) {
+      return rule.iata;
+    }
+    if (rule.htmlFingerprints.some((fp) => htmlContent.toLowerCase().includes(fp))) {
+      return rule.iata;
+    }
+  }
+  return null;
+}

--- a/backend/src/services/parsers/templates/engine.ts
+++ b/backend/src/services/parsers/templates/engine.ts
@@ -1,18 +1,11 @@
 import * as cheerio from "cheerio";
-import type { AirlineTemplate, SelectorKey } from "./types";
+import { TRANSFORMS, type AirlineTemplate, type SelectorKey, type TransformName } from "./types";
 import type { ParsedBooking } from "../../bookingParser";
 
 const CRITICAL_FIELDS: SelectorKey[] = ["flightNumber", "departureCode", "arrivalCode"];
 
-function safeTransform(transform: string, value: string): string {
-  try {
-    // eslint-disable-next-line no-new-func
-    const fn = new Function("value", `return (${transform})(value)`) as (v: string) => string;
-    const result = fn(value);
-    return typeof result === "string" ? result : value;
-  } catch {
-    return value;
-  }
+function applyTransform(transformName: TransformName, value: string): string {
+  return TRANSFORMS[transformName](value);
 }
 
 const SELECTOR_TO_BOOKING_KEY: Partial<Record<SelectorKey, keyof ParsedBooking>> = {
@@ -69,11 +62,25 @@ export function applyTemplate(
 
     if (value) {
       const transform = template.transforms[sKey];
-      const finalValue = transform ? safeTransform(transform, value) : value;
+      const finalValue = transform ? applyTransform(transform, value) : value;
       (result as unknown as Record<string, unknown>)[bookingKey] = finalValue;
       matchedFields++;
     } else if (CRITICAL_FIELDS.includes(sKey)) {
       result.missing.push(bookingKey as string);
+    }
+  }
+
+  // Special handling for coPassengers (comma/semicolon-separated list)
+  const coPassengersSelector = template.selectors.coPassengers;
+  if ($ && coPassengersSelector) {
+    const el = $(coPassengersSelector);
+    totalFields++;
+    if (el.length > 0) {
+      const rawText = el.first().text().trim();
+      if (rawText) {
+        result.coPassengers = rawText.split(/[,;]/).map((s) => s.trim()).filter(Boolean);
+        matchedFields++;
+      }
     }
   }
 

--- a/backend/src/services/parsers/templates/engine.ts
+++ b/backend/src/services/parsers/templates/engine.ts
@@ -1,0 +1,87 @@
+import * as cheerio from "cheerio";
+import type { AirlineTemplate, SelectorKey } from "./types";
+import type { ParsedBooking } from "../../bookingParser";
+
+const CRITICAL_FIELDS: SelectorKey[] = ["flightNumber", "departureCode", "arrivalCode"];
+
+function safeTransform(transform: string, value: string): string {
+  try {
+    // eslint-disable-next-line no-new-func
+    const fn = new Function("value", `return (${transform})(value)`) as (v: string) => string;
+    const result = fn(value);
+    return typeof result === "string" ? result : value;
+  } catch {
+    return value;
+  }
+}
+
+const SELECTOR_TO_BOOKING_KEY: Partial<Record<SelectorKey, keyof ParsedBooking>> = {
+  flightNumber: "flightNumber",
+  pnr: "bookingReference",
+  departureTime: "departureTime",
+  arrivalTime: "arrivalTime",
+  departureCode: "departureCode",
+  arrivalCode: "arrivalCode",
+  seat: "seat",
+  seatClass: "seatClass",
+  price: "price",
+  currency: "currency",
+  taxes: "taxes",
+  fees: "fees",
+  baggage: "baggageAllowance",
+  frequentFlyer: "frequentFlyerNumber",
+  ticketNumber: "ticketNumber",
+  bookingClassLetter: "bookingClassLetter",
+  terminal: "terminal",
+  gate: "gate",
+};
+
+export function applyTemplate(
+  template: AirlineTemplate,
+  _plainText: string,
+  htmlContent: string
+): ParsedBooking {
+  const $ = htmlContent ? cheerio.load(htmlContent) : null;
+  const result: ParsedBooking = {
+    missing: [],
+    parserTemplate: template.iata,
+    parserConfidence: 0,
+  };
+
+  let matchedFields = 0;
+  let totalFields = 0;
+
+  const entries = Object.entries(SELECTOR_TO_BOOKING_KEY) as [SelectorKey, keyof ParsedBooking][];
+
+  for (const [sKey, bookingKey] of entries) {
+    const selector = template.selectors[sKey];
+    if (!selector) continue;
+
+    totalFields++;
+    let value: string | undefined;
+
+    if ($) {
+      const el = $(selector);
+      if (el.length > 0) {
+        value = el.first().text().trim() || el.first().attr("data-value")?.trim();
+      }
+    }
+
+    if (value) {
+      const transform = template.transforms[sKey];
+      const finalValue = transform ? safeTransform(transform, value) : value;
+      (result as unknown as Record<string, unknown>)[bookingKey] = finalValue;
+      matchedFields++;
+    } else if (CRITICAL_FIELDS.includes(sKey)) {
+      result.missing.push(bookingKey as string);
+    }
+  }
+
+  result.parserConfidence = totalFields > 0 ? Math.round((matchedFields / totalFields) * 100) : 0;
+
+  if (result.bookingReference) {
+    result.pnr = result.bookingReference;
+  }
+
+  return result;
+}

--- a/backend/src/services/parsers/templates/registry.ts
+++ b/backend/src/services/parsers/templates/registry.ts
@@ -1,0 +1,148 @@
+import fs from "fs";
+import path from "path";
+import https from "https";
+import { isValidAirlineTemplate, type AirlineTemplate } from "./types";
+import logger from "../../../utils/logger";
+
+const BUILTIN_DIR = path.join(__dirname, "airlines");
+const CACHE_DIR = path.join(process.cwd(), ".template-cache");
+const GITHUB_RAW_BASE =
+  "https://raw.githubusercontent.com/travstats-community/airline-templates/main/templates";
+const INDEX_URL = `${GITHUB_RAW_BASE}/index.json`;
+const SYNC_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+
+interface TemplateIndex {
+  version: string;
+  airlines: { iata: string; version: string }[];
+}
+
+export interface TemplateStatusEntry {
+  iata: string;
+  airline: string;
+  version: string;
+  source: "builtin" | "cached";
+}
+
+class TemplateRegistry {
+  private templates: Map<string, AirlineTemplate> = new Map();
+  private templateSources: Map<string, "builtin" | "cached"> = new Map();
+
+  async initialize(): Promise<void> {
+    await this.loadBuiltinTemplates();
+    await this.loadCachedTemplates();
+    this.scheduleSync();
+  }
+
+  private async loadBuiltinTemplates(): Promise<void> {
+    if (!fs.existsSync(BUILTIN_DIR)) return;
+    const files = fs.readdirSync(BUILTIN_DIR).filter((f) => f.endsWith(".json"));
+    for (const file of files) {
+      try {
+        const raw = fs.readFileSync(path.join(BUILTIN_DIR, file), "utf-8");
+        const content: unknown = JSON.parse(raw);
+        if (isValidAirlineTemplate(content)) {
+          this.templates.set(content.iata, content);
+          this.templateSources.set(content.iata, "builtin");
+        }
+      } catch (err) {
+        logger.warn({ file, err }, "Failed to load builtin template");
+      }
+    }
+    logger.info({ count: this.templates.size }, "Builtin templates loaded");
+  }
+
+  private async loadCachedTemplates(): Promise<void> {
+    if (!fs.existsSync(CACHE_DIR)) return;
+    const files = fs.readdirSync(CACHE_DIR).filter((f) => f.endsWith(".json"));
+    for (const file of files) {
+      if (file === "index.json") continue;
+      try {
+        const raw = fs.readFileSync(path.join(CACHE_DIR, file), "utf-8");
+        const content: unknown = JSON.parse(raw);
+        if (isValidAirlineTemplate(content)) {
+          const existing = this.templates.get(content.iata);
+          if (!existing || content.version > existing.version) {
+            this.templates.set(content.iata, content);
+            this.templateSources.set(content.iata, "cached");
+          }
+        }
+      } catch {
+        // Ignore malformed cache files silently
+      }
+    }
+  }
+
+  getTemplate(iata: string): AirlineTemplate | null {
+    return this.templates.get(iata) ?? null;
+  }
+
+  getAll(): AirlineTemplate[] {
+    return Array.from(this.templates.values());
+  }
+
+  getStatus(): TemplateStatusEntry[] {
+    return Array.from(this.templates.entries()).map(([iata, t]) => ({
+      iata,
+      airline: t.airline,
+      version: t.version,
+      source: this.templateSources.get(iata) ?? "builtin",
+    }));
+  }
+
+  private scheduleSync(): void {
+    setTimeout(() => {
+      void this.syncFromGitHub();
+    }, 5000);
+    setInterval(() => {
+      void this.syncFromGitHub();
+    }, SYNC_INTERVAL_MS);
+  }
+
+  private async syncFromGitHub(): Promise<void> {
+    try {
+      const index = await this.fetchJson<TemplateIndex>(INDEX_URL);
+      if (!fs.existsSync(CACHE_DIR)) fs.mkdirSync(CACHE_DIR, { recursive: true });
+
+      for (const entry of index.airlines) {
+        const existing = this.templates.get(entry.iata);
+        if (existing && existing.version >= entry.version) continue;
+
+        const url = `${GITHUB_RAW_BASE}/${entry.iata}.json`;
+        const template = await this.fetchJson<unknown>(url);
+        if (isValidAirlineTemplate(template)) {
+          this.templates.set(template.iata, template);
+          this.templateSources.set(template.iata, "cached");
+          fs.writeFileSync(
+            path.join(CACHE_DIR, `${template.iata}.json`),
+            JSON.stringify(template),
+          );
+        }
+      }
+      logger.info({ count: index.airlines.length }, "Templates synced from GitHub");
+    } catch (err) {
+      logger.warn({ err }, "GitHub template sync failed — using cached/builtin templates");
+    }
+  }
+
+  private fetchJson<T>(url: string): Promise<T> {
+    return new Promise((resolve, reject) => {
+      https
+        .get(url, (res) => {
+          let data = "";
+          res.on("data", (chunk: string) => {
+            data += chunk;
+          });
+          res.on("end", () => {
+            try {
+              resolve(JSON.parse(data) as T);
+            } catch (e) {
+              reject(e);
+            }
+          });
+        })
+        .on("error", reject);
+    });
+  }
+}
+
+export const templateRegistry = new TemplateRegistry();

--- a/backend/src/services/parsers/templates/registry.ts
+++ b/backend/src/services/parsers/templates/registry.ts
@@ -66,8 +66,8 @@ class TemplateRegistry {
             this.templateSources.set(content.iata, "cached");
           }
         }
-      } catch {
-        // Ignore malformed cache files silently
+      } catch (err) {
+        logger.debug({ file, err }, "Skipped malformed cache file");
       }
     }
   }
@@ -93,6 +93,7 @@ class TemplateRegistry {
     setTimeout(() => {
       void this.syncFromGitHub();
     }, 5000);
+    // Singleton registry — interval runs for process lifetime (intentional)
     setInterval(() => {
       void this.syncFromGitHub();
     }, SYNC_INTERVAL_MS);
@@ -126,21 +127,28 @@ class TemplateRegistry {
 
   private fetchJson<T>(url: string): Promise<T> {
     return new Promise((resolve, reject) => {
-      https
-        .get(url, (res) => {
-          let data = "";
-          res.on("data", (chunk: string) => {
-            data += chunk;
-          });
-          res.on("end", () => {
-            try {
-              resolve(JSON.parse(data) as T);
-            } catch (e) {
-              reject(e);
-            }
-          });
-        })
-        .on("error", reject);
+      const req = https.get(url, (res) => {
+        if (res.statusCode !== 200) {
+          reject(new Error(`HTTP ${res.statusCode ?? "unknown"} from ${url}`));
+          res.resume(); // drain the response
+          return;
+        }
+        let data = "";
+        res.on("data", (chunk: string) => {
+          data += chunk;
+        });
+        res.on("end", () => {
+          try {
+            resolve(JSON.parse(data) as T);
+          } catch (e) {
+            reject(e);
+          }
+        });
+      });
+      req.setTimeout(10000, () => {
+        req.destroy(new Error(`Timeout fetching ${url}`));
+      });
+      req.on("error", reject);
     });
   }
 }

--- a/backend/src/services/parsers/templates/types.ts
+++ b/backend/src/services/parsers/templates/types.ts
@@ -22,6 +22,25 @@ export interface AirlineTemplateSelectors {
 
 export type SelectorKey = keyof AirlineTemplateSelectors;
 
+export type TransformName =
+  | "trim"
+  | "uppercase"
+  | "lowercase"
+  | "extractIata"
+  | "extractFlightNumber"
+  | "removeSpaces"
+  | "stripNonAlpha";
+
+export const TRANSFORMS: Record<TransformName, (value: string) => string> = {
+  trim: (v) => v.trim(),
+  uppercase: (v) => v.toUpperCase(),
+  lowercase: (v) => v.toLowerCase(),
+  extractIata: (v) => v.match(/\b[A-Z]{3}\b/)?.[0] ?? v,
+  extractFlightNumber: (v) => v.match(/[A-Z]{2,3}\d{1,4}/)?.[0] ?? v,
+  removeSpaces: (v) => v.replace(/\s+/g, ""),
+  stripNonAlpha: (v) => v.replace(/[^A-Za-z0-9]/g, ""),
+};
+
 export interface AirlineTemplateTestCase {
   input: string;
   expected: Partial<Record<SelectorKey, string>>;
@@ -34,7 +53,7 @@ export interface AirlineTemplate {
   from: string[];
   subject: string[];
   selectors: AirlineTemplateSelectors;
-  transforms: Partial<Record<SelectorKey, string>>;
+  transforms: Partial<Record<SelectorKey, TransformName>>;
   testCases: AirlineTemplateTestCase[];
 }
 
@@ -42,12 +61,15 @@ export function isValidAirlineTemplate(obj: unknown): obj is AirlineTemplate {
   if (typeof obj !== "object" || obj === null) return false;
   const t = obj as Record<string, unknown>;
   return (
-    typeof t["airline"] === "string" &&
-    typeof t["iata"] === "string" &&
-    typeof t["version"] === "string" &&
-    Array.isArray(t["from"]) &&
-    Array.isArray(t["subject"]) &&
-    typeof t["selectors"] === "object" &&
-    t["selectors"] !== null
+    typeof t.airline === "string" &&
+    typeof t.iata === "string" &&
+    typeof t.version === "string" &&
+    Array.isArray(t.from) &&
+    Array.isArray(t.subject) &&
+    typeof t.selectors === "object" &&
+    t.selectors !== null &&
+    typeof t.transforms === "object" &&
+    t.transforms !== null &&
+    Array.isArray(t.testCases)
   );
 }

--- a/backend/src/services/parsers/templates/types.ts
+++ b/backend/src/services/parsers/templates/types.ts
@@ -1,0 +1,53 @@
+export interface AirlineTemplateSelectors {
+  flightNumber?: string;
+  pnr?: string;
+  departureTime?: string;
+  arrivalTime?: string;
+  departureCode?: string;
+  arrivalCode?: string;
+  seat?: string;
+  seatClass?: string;
+  price?: string;
+  currency?: string;
+  taxes?: string;
+  fees?: string;
+  baggage?: string;
+  frequentFlyer?: string;
+  ticketNumber?: string;
+  bookingClassLetter?: string;
+  terminal?: string;
+  gate?: string;
+  coPassengers?: string;
+}
+
+export type SelectorKey = keyof AirlineTemplateSelectors;
+
+export interface AirlineTemplateTestCase {
+  input: string;
+  expected: Partial<Record<SelectorKey, string>>;
+}
+
+export interface AirlineTemplate {
+  airline: string;
+  iata: string;
+  version: string;
+  from: string[];
+  subject: string[];
+  selectors: AirlineTemplateSelectors;
+  transforms: Partial<Record<SelectorKey, string>>;
+  testCases: AirlineTemplateTestCase[];
+}
+
+export function isValidAirlineTemplate(obj: unknown): obj is AirlineTemplate {
+  if (typeof obj !== "object" || obj === null) return false;
+  const t = obj as Record<string, unknown>;
+  return (
+    typeof t["airline"] === "string" &&
+    typeof t["iata"] === "string" &&
+    typeof t["version"] === "string" &&
+    Array.isArray(t["from"]) &&
+    Array.isArray(t["subject"]) &&
+    typeof t["selectors"] === "object" &&
+    t["selectors"] !== null
+  );
+}

--- a/backend/src/services/parsers/text/templateParser.ts
+++ b/backend/src/services/parsers/text/templateParser.ts
@@ -1,0 +1,51 @@
+import type { ProviderAvailability } from "../types";
+import type { ParsedBooking } from "../../bookingParser";
+import { templateRegistry } from "../templates/registry";
+import { detectAirline } from "../templates/detector";
+import { applyTemplate } from "../templates/engine";
+import { buildAirlineNotice, recordParseResult } from "../../trainingRecorder";
+import logger from "../../../utils/logger";
+
+export class TemplateParser {
+  async checkAvailability(): Promise<ProviderAvailability> {
+    const count = templateRegistry.getAll().length;
+    return {
+      available: count > 0,
+      reason: count === 0 ? "No templates loaded" : undefined,
+    };
+  }
+
+  async parseEmail(
+    subject: string,
+    text: string,
+    html: string | undefined,
+    userId?: string
+  ): Promise<ParsedBooking[]> {
+    const fromMatch = /^From:\s*(.+)$/im.exec(text);
+    const fromAddress = fromMatch ? fromMatch[1].trim() : "";
+
+    const detectedIata = detectAirline(fromAddress, subject, html ?? "");
+    const template = detectedIata ? templateRegistry.getTemplate(detectedIata) : null;
+
+    if (userId) {
+      void recordParseResult({
+        userId,
+        airline: detectedIata ?? undefined,
+        templateUsed: template?.iata,
+        templateHit: template !== null,
+        fieldCount: 0,
+        missingFields: [],
+        parserProvider: "template",
+      });
+    }
+
+    if (!template) {
+      logger.debug({ detectedIata, subject }, "No template found for airline");
+      return [];
+    }
+
+    const parsed = applyTemplate(template, text, html ?? "");
+    parsed.airlineNotice = buildAirlineNotice(detectedIata);
+    return [parsed];
+  }
+}

--- a/backend/src/services/parsers/types.ts
+++ b/backend/src/services/parsers/types.ts
@@ -109,6 +109,7 @@ export interface ParserConfig {
   claudeApiKey?: string;
   claudeModel?: string;
   claudeVisionModel?: string;
+  userId?: string;
 }
 
 /**

--- a/backend/src/services/trainingRecorder.ts
+++ b/backend/src/services/trainingRecorder.ts
@@ -1,0 +1,38 @@
+import { prisma } from "../db";
+import logger from "../utils/logger";
+
+interface ParseTrainingRecord {
+  userId: string; // Stored for debugging/rate-limits, stripped during export (Phase 4)
+  airline?: string;
+  templateUsed?: string;
+  templateHit: boolean;
+  confidence?: number;
+  fieldCount: number;
+  missingFields: string[];
+  parserProvider: string;
+}
+
+export async function recordParseResult(record: ParseTrainingRecord): Promise<void> {
+  try {
+    await prisma.parseTrainingLog.create({
+      data: {
+        userId: record.userId,
+        airline: record.airline ?? null,
+        templateUsed: record.templateUsed ?? null,
+        templateHit: record.templateHit,
+        confidence: record.confidence ?? null,
+        fieldCount: record.fieldCount,
+        missingFields: record.missingFields,
+        parserProvider: record.parserProvider,
+      },
+    });
+  } catch (err) {
+    // Non-blocking — training recording should never break the main flow
+    logger.warn({ err }, "Failed to record parse training data");
+  }
+}
+
+export function buildAirlineNotice(detectedAirline: string | null): string | undefined {
+  if (detectedAirline) return undefined;
+  return "Für diese Airline wurde kein Template gefunden. Hilf der Community und trage eines bei: https://github.com/travstats-community/airline-templates";
+}

--- a/frontend/src/components/SimplifiedFlightFormV2.tsx
+++ b/frontend/src/components/SimplifiedFlightFormV2.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useState, useEffect, useMemo, useRef, lazy, Suspense } from "react";
-import { Airport, airportsApi, parseApi } from "../lib/api";
+import { Airport, airportsApi } from "../lib/api";
 import AirportAutocomplete from "./AirportAutocomplete";
 import HelpIcon from "./Help/HelpIcon";
 import { useTranslation } from "../hooks/useTranslation";
@@ -19,6 +19,7 @@ import { logger } from "../lib/logger";
 
 // Lazy load BoardingPassScanner as it's heavy (Tesseract.js)
 const BoardingPassScanner = lazy(() => import("./BoardingPassScanner"));
+const EmailImportTab = lazy(() => import("./import/EmailImportTab"));
 import FlightReviewModal from "./FlightReviewModal";
 import type { FlightInput } from "../types";
 import { useSettingsStore } from "../store/settingsStore";
@@ -93,9 +94,6 @@ export default function SimplifiedFlightFormV2({
   const [originalEmailData, setOriginalEmailData] = useState<
     { subject?: string; text?: string; html?: string } | undefined
   >();
-  const [emailUploading, setEmailUploading] = useState(false);
-  const emailFileInputRef = useRef<HTMLInputElement>(null);
-
   // Flight Lookup State
   const [flightNumber, setFlightNumber] = useState("");
   const [searchDate, setSearchDate] = useState("");
@@ -125,6 +123,10 @@ export default function SimplifiedFlightFormV2({
   const [tags, setTags] = useState<string[]>([]);
   const [companions, setCompanions] = useState<string[]>([]);
   const [companionInput, setCompanionInput] = useState("");
+  const [baggageAllowance, setBaggageAllowance] = useState<string | undefined>(undefined);
+  const [frequentFlyerNumber, setFrequentFlyerNumber] = useState<string | undefined>(undefined);
+  const [bookingClassLetter, setBookingClassLetter] = useState<string | undefined>(undefined);
+  const [coPassengers, setCoPassengers] = useState<string[]>([]);
 
   // Initialize defaults from settings
   useEffect(() => {
@@ -436,6 +438,10 @@ export default function SimplifiedFlightFormV2({
         category,
         tags: tags.length ? tags : undefined,
         companions: companions.length ? companions : undefined,
+        baggageAllowance,
+        frequentFlyerNumber,
+        bookingClassLetter,
+        coPassengers: coPassengers.length ? coPassengers : undefined,
       });
     } catch (err: unknown) {
       const errorObj = err as {
@@ -520,6 +526,10 @@ export default function SimplifiedFlightFormV2({
           category,
           tags: tags.length ? tags : undefined,
           companions: companions.length ? companions : undefined,
+          baggageAllowance,
+          frequentFlyerNumber,
+          bookingClassLetter,
+          coPassengers: coPassengers.length ? coPassengers : undefined,
         },
         true
       );
@@ -1240,107 +1250,40 @@ export default function SimplifiedFlightFormV2({
       {/* Email Uploader Modal */}
       {showEmailUploader && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-          <div className={`${bgClass} rounded-lg p-6 max-w-md w-full`}>
+          <div className={`${bgClass} rounded-lg p-6 max-w-md w-full mx-4`}>
             <h3 className={`text-xl font-bold ${textClass} mb-4`}>
               {t("flights:form.email.title")}
             </h3>
-
-            <input
-              ref={emailFileInputRef}
-              type="file"
-              accept=".eml,.msg,.txt"
-              onChange={async (e) => {
-                const file = e.target.files?.[0];
-                if (!file) return;
-
-                setEmailUploading(true);
-                setError("");
-
-                try {
-                  const result = await parseApi.parseEmailFile(file);
-
-                  if (
-                    result &&
-                    result.flights &&
-                    Array.isArray(result.flights) &&
-                    result.flights.length > 0
-                  ) {
-                    // Store parsed flights
-                    setParsedFlights(result.flights);
+            <Suspense fallback={<div className="p-6 text-center text-slate-400">Lädt...</div>}>
+              <EmailImportTab
+                onResult={(flights, subject, provider, text, html) => {
+                  if (flights.length > 0) {
+                    setParsedFlights(flights);
                     setCurrentFlightIndex(0);
-
-                    // Store parser provider and original data
-                    setParserProvider(result.provider || "unknown");
-                    setOriginalEmailData({
-                      subject: result.subject,
-                      text: result.text,
-                      html: result.html,
-                    });
-
-                    // Close email uploader and show flight review
+                    setParserProvider(provider ?? "template");
+                    setOriginalEmailData({ subject, text, html });
                     setShowEmailUploader(false);
                     setShowFlightReview(true);
                   } else {
                     setError(t("flights:form.noFlightsInEmail"));
                   }
-                } catch (err: unknown) {
-                  logger.error("Failed to parse email:", err);
-                  const axiosError = err as {
-                    response?: { data?: { error?: string } };
-                    message?: string;
-                  };
-                  setError(
-                    axiosError.response?.data?.error ||
-                      axiosError.message ||
-                      t("flights:form.noFlightsInEmail")
-                  );
-                } finally {
-                  setEmailUploading(false);
-                }
-              }}
-              className="hidden"
-              disabled={emailUploading}
-            />
-
-            {emailUploading ? (
-              <div className="text-center py-8">
-                <div className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-blue-500 mx-auto mb-4"></div>
-                <p className={`${mutedTextClass}`}>{t("flights:form.loadingScanner")}</p>
-              </div>
-            ) : (
-              <>
-                <div
-                  className={`border-2 border-dashed ${isDarkMode ? "border-[var(--color-border)]" : "border-[var(--color-border)]"} rounded-lg p-8 text-center cursor-pointer hover:border-blue-500 transition-colors mb-4`}
-                  onClick={() => emailFileInputRef.current?.click()}
-                >
-                  <div className="text-5xl mb-4">📧</div>
-                  <p className={`font-semibold ${textClass} mb-2`}>
-                    {t("flights:form.uploadEmail")}
-                  </p>
-                  <p className={`text-sm ${mutedTextClass}`}>
-                    {t("flights:form.email.description")}
-                  </p>
-                  <p className={`text-xs ${mutedTextClass} mt-2`}>.eml, .msg, .txt</p>
-                </div>
-
-                {error && (
-                  <div className="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4">
-                    {error}
-                  </div>
-                )}
-              </>
-            )}
-
-            <div className="flex gap-3 justify-end mt-4">
+                }}
+                onError={(message) => {
+                  setError(message);
+                  setShowEmailUploader(false);
+                }}
+              />
+            </Suspense>
+            <div className="flex justify-end mt-4">
               <button
+                type="button"
                 onClick={() => {
                   setShowEmailUploader(false);
                   setError("");
                 }}
                 className="btn-secondary"
-                disabled={emailUploading}
               >
-                {t("common:buttons.close")}
+                {t("common:buttons.cancel")}
               </button>
             </div>
           </div>
@@ -1357,7 +1300,19 @@ export default function SimplifiedFlightFormV2({
             setCurrentFlightIndex(0);
           }}
           onConfirm={async (flightData) => {
-            await onSubmit(flightData);
+            const sourceFlight = parsedFlights[currentFlightIndex];
+            setBaggageAllowance(sourceFlight?.baggageAllowance);
+            setFrequentFlyerNumber(sourceFlight?.frequentFlyerNumber);
+            setBookingClassLetter(sourceFlight?.bookingClassLetter);
+            setCoPassengers(sourceFlight?.coPassengers ?? []);
+
+            await onSubmit({
+              ...flightData,
+              baggageAllowance: sourceFlight?.baggageAllowance,
+              frequentFlyerNumber: sourceFlight?.frequentFlyerNumber,
+              bookingClassLetter: sourceFlight?.bookingClassLetter,
+              coPassengers: sourceFlight?.coPassengers,
+            });
 
             // Check if there are more flights to process
             const nextIndex = currentFlightIndex + 1;

--- a/frontend/src/components/TemplateStatusView.tsx
+++ b/frontend/src/components/TemplateStatusView.tsx
@@ -1,0 +1,58 @@
+import { useEffect, useState } from "react";
+import { templateApi } from "../lib/api";
+import type { TemplateStatusEntry } from "../lib/api";
+import { logger } from "../lib/logger";
+
+export default function TemplateStatusView(): JSX.Element {
+  const [templates, setTemplates] = useState<TemplateStatusEntry[]>([]);
+  const [githubRepo, setGithubRepo] = useState("");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    void templateApi
+      .getStatus()
+      .then((data) => {
+        setTemplates(data.templates);
+        setGithubRepo(data.githubRepo);
+      })
+      .catch((err: unknown) => logger.error("Failed to load template status", err))
+      .finally(() => setLoading(false));
+  }, []);
+
+  if (loading) {
+    return <div className="text-slate-400 text-sm">Lade Templates...</div>;
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-semibold text-slate-200">Airline Email Templates</h3>
+        {githubRepo && (
+          <a
+            href={githubRepo}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-blue-400 hover:text-blue-300 underline"
+          >
+            Templates beisteuern →
+          </a>
+        )}
+      </div>
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+        {templates.map((t) => (
+          <div
+            key={t.iata}
+            className="bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm flex items-center gap-2"
+          >
+            <span className="font-mono text-blue-400 shrink-0">{t.iata}</span>
+            <span className="text-slate-300 truncate flex-1">{t.airline}</span>
+            <span className="text-xs text-slate-500 shrink-0">v{t.version.slice(0, 7)}</span>
+          </div>
+        ))}
+      </div>
+      <p className="text-xs text-slate-500">
+        {templates.length} Templates geladen · Tägl. Auto-Update aus GitHub
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/components/import/EmailImportTab.tsx
+++ b/frontend/src/components/import/EmailImportTab.tsx
@@ -1,0 +1,159 @@
+import { useState, useRef, useCallback } from "react";
+import { parseApi } from "../../lib/api";
+import type { ParsedBooking } from "../../types";
+import { useTranslation } from "../../hooks/useTranslation";
+import { logger } from "../../lib/logger";
+
+interface EmailImportTabProps {
+  onResult: (
+    flights: ParsedBooking[],
+    subject?: string,
+    provider?: string,
+    text?: string,
+    html?: string
+  ) => void;
+  onError: (message: string) => void;
+}
+
+type DropState = "idle" | "over" | "loading";
+
+export default function EmailImportTab({ onResult, onError }: EmailImportTabProps): JSX.Element {
+  const { t } = useTranslation(["flights", "common"]);
+  const [dropState, setDropState] = useState<DropState>("idle");
+  const [airlineNotice, setAirlineNotice] = useState<string | null>(null);
+  const [emailText, setEmailText] = useState("");
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleFile = useCallback(
+    async (file: File): Promise<void> => {
+      const allowed = [".eml", ".msg", ".txt"];
+      const isPdf = file.name.endsWith(".pdf");
+
+      if (isPdf) {
+        onError(
+          "PDF-Dateien werden direkt noch nicht unterstützt. Öffne die Email in deinem Email-Client und nutze 'Weiterleiten' oder kopiere den Text."
+        );
+        return;
+      }
+
+      if (!allowed.some((ext) => file.name.endsWith(ext))) {
+        onError(`Unterstützte Formate: ${allowed.join(", ")}`);
+        return;
+      }
+
+      setDropState("loading");
+      try {
+        const result = await parseApi.parseEmailFile(file);
+        setAirlineNotice(result.airlineNotice ?? null);
+        if (result.flights.length > 0) {
+          onResult(result.flights, result.subject, result.provider, result.text, result.html);
+        } else {
+          onError(t("flights:form.noFlightsInEmail"));
+        }
+      } catch (err) {
+        logger.error("Email parse failed", err);
+        onError(t("flights:form.noFlightsInEmail"));
+      } finally {
+        setDropState("idle");
+      }
+    },
+    [onResult, onError, t]
+  );
+
+  const handleTextParse = useCallback(async (): Promise<void> => {
+    if (!emailText.trim()) return;
+    setDropState("loading");
+    try {
+      const result = await parseApi.parseEmail(emailText);
+      setAirlineNotice(result.airlineNotice ?? null);
+      if (result.flights.length > 0) {
+        onResult(result.flights, result.subject, result.provider, result.text, result.html);
+      } else {
+        onError(t("flights:form.noFlightsInEmail"));
+      }
+    } catch (err) {
+      logger.error("Email text parse failed", err);
+      onError(t("flights:form.noFlightsInEmail"));
+    } finally {
+      setDropState("idle");
+    }
+  }, [emailText, onResult, onError, t]);
+
+  const onDrop = useCallback(
+    (e: React.DragEvent<HTMLDivElement>): void => {
+      e.preventDefault();
+      setDropState("idle");
+      const file = e.dataTransfer.files[0];
+      if (file) void handleFile(file);
+    },
+    [handleFile]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      {/* Drag & Drop Zone */}
+      <div
+        onDrop={onDrop}
+        onDragOver={(e) => {
+          e.preventDefault();
+          setDropState("over");
+        }}
+        onDragLeave={() => setDropState("idle")}
+        onClick={() => fileInputRef.current?.click()}
+        className={[
+          "border-2 border-dashed rounded-xl p-8 text-center cursor-pointer transition-colors",
+          dropState === "over"
+            ? "border-blue-400 bg-blue-950/20"
+            : "border-slate-600 hover:border-slate-400",
+          dropState === "loading" ? "opacity-50 pointer-events-none" : "",
+        ].join(" ")}
+      >
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept=".eml,.msg,.txt,.pdf"
+          className="hidden"
+          onChange={(e) => {
+            if (e.target.files?.[0]) void handleFile(e.target.files[0]);
+          }}
+        />
+        <div className="text-3xl mb-2">📧</div>
+        <p className="font-medium text-slate-200">
+          {dropState === "loading" ? t("common:messages.loading") : t("flights:form.uploadEmail")}
+        </p>
+        <p className="text-sm text-slate-400 mt-1">.eml, .msg, .txt</p>
+        <p className="text-xs text-slate-500 mt-1">PDF: Nur Erkennung, kein automatisches Parsen</p>
+      </div>
+
+      {/* Airline Notice */}
+      {airlineNotice && (
+        <div className="text-sm text-yellow-400 bg-yellow-900/20 border border-yellow-700 rounded-lg px-4 py-3">
+          ⚠️ {airlineNotice}
+        </div>
+      )}
+
+      {/* Text Paste Fallback */}
+      <details className="text-sm text-slate-400">
+        <summary className="cursor-pointer hover:text-slate-200">
+          {t("flights:form.email.textFallback")}
+        </summary>
+        <div className="mt-3 flex flex-col gap-2">
+          <textarea
+            value={emailText}
+            onChange={(e) => setEmailText(e.target.value)}
+            className="w-full h-32 bg-slate-800 border border-slate-600 rounded-lg p-3 text-sm text-slate-200 resize-none"
+            placeholder={t("flights:form.email.textPlaceholder")}
+          />
+          <button
+            type="button"
+            onClick={() => void handleTextParse()}
+            disabled={!emailText.trim() || dropState === "loading"}
+            className="self-end px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-lg text-sm font-medium text-white"
+          >
+            {t("common:parse")}
+          </button>
+        </div>
+      </details>
+    </div>
+  );
+}

--- a/frontend/src/components/import/EmailImportTab.tsx
+++ b/frontend/src/components/import/EmailImportTab.tsx
@@ -150,7 +150,7 @@ export default function EmailImportTab({ onResult, onError }: EmailImportTabProp
             disabled={!emailText.trim() || dropState === "loading"}
             className="self-end px-4 py-2 bg-blue-600 hover:bg-blue-500 disabled:opacity-50 rounded-lg text-sm font-medium text-white"
           >
-            {t("common:parse")}
+            {t("common:messages.parse")}
           </button>
         </div>
       </details>

--- a/frontend/src/i18n/resources/de/common.json
+++ b/frontend/src/i18n/resources/de/common.json
@@ -89,6 +89,7 @@
     "noResults": "Keine Ergebnisse gefunden",
     "loading": "Lädt...",
     "pleaseWait": "Bitte warten",
+    "parse": "Parsen",
     "saved": "Erfolgreich gespeichert",
     "deleted": "Erfolgreich gelöscht",
     "updated": "Erfolgreich aktualisiert",

--- a/frontend/src/i18n/resources/de/flights.json
+++ b/frontend/src/i18n/resources/de/flights.json
@@ -80,7 +80,9 @@
       "description": "Importieren Sie Flüge direkt aus Bestätigungs-E-Mails!",
       "import": "E-Mail importieren",
       "bestOption": "Beste Option",
-      "bestOptionDescription": "Erfasst alle Daten am besten aus Bestätigungs-E-Mails"
+      "bestOptionDescription": "Erfasst alle Daten am besten aus Bestätigungs-E-Mails",
+      "textFallback": "Email-Text einfügen (Fallback)",
+      "textPlaceholder": "Email-Inhalt hier einfügen..."
     },
     "simplified": {
       "subtitle": "Geben Sie einfach Abflug- und Ankunftsflughafen ein – wir erledigen den Rest!",

--- a/frontend/src/i18n/resources/en/common.json
+++ b/frontend/src/i18n/resources/en/common.json
@@ -89,6 +89,7 @@
     "noResults": "No results found",
     "loading": "Loading...",
     "pleaseWait": "Please wait",
+    "parse": "Parse",
     "saved": "Saved successfully",
     "deleted": "Deleted successfully",
     "updated": "Updated successfully",

--- a/frontend/src/i18n/resources/en/flights.json
+++ b/frontend/src/i18n/resources/en/flights.json
@@ -81,7 +81,9 @@
       "import": "Import Email",
       "bestOption": "Best Option",
       "bestOptionDescription": "Captures all data best from confirmation emails",
-      "notImplemented": "Email import is not yet implemented. Please use manual entry or boarding pass scan."
+      "notImplemented": "Email import is not yet implemented. Please use manual entry or boarding pass scan.",
+      "textFallback": "Paste email text (fallback)",
+      "textPlaceholder": "Paste email content here..."
     },
     "simplified": {
       "subtitle": "Just enter departure & arrival airports - we'll handle the rest!",

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -2040,4 +2040,24 @@ export const calculateDistance = (
   return R * c;
 };
 
+export interface TemplateStatusEntry {
+  iata: string;
+  airline: string;
+  version: string;
+  source: "builtin" | "cached";
+}
+
+export interface TemplateStatusResult {
+  templates: TemplateStatusEntry[];
+  total: number;
+  githubRepo: string;
+}
+
+export const templateApi = {
+  getStatus: async (): Promise<TemplateStatusResult> => {
+    const res = await api.get<TemplateStatusResult>("/template-status");
+    return res.data;
+  },
+};
+
 export default api;

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -78,6 +78,7 @@ export interface EmailParseResult {
   subject?: string;
   text?: string;
   html?: string;
+  airlineNotice?: string | null;
 }
 
 /** Ollama vision check response */

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { useSettingsStore } from "../store/settingsStore";
 import { useThemeStore } from "../store/themeStore";
 import { useAuthStore } from "../store/authStore";
 import ParserConfiguration from "../components/Settings/ParserConfiguration";
+import TemplateStatusView from "../components/TemplateStatusView";
 import ApiKeyCard from "../components/Settings/ApiKeyCard";
 import NotificationPreferences from "../components/Settings/NotificationPreferences";
 import { settingsApi, authApi, backupApi } from "../lib/api";
@@ -1261,6 +1262,7 @@ export default function SettingsPage(): JSX.Element {
                   </p>
                 </div>
                 <ParserConfiguration />
+                <TemplateStatusView />
               </SectionCard>
             )}
             {/* Auto-Update */}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -108,6 +108,10 @@ export interface FlightInput {
   tags?: string[];
   companions?: string[];
   receiptUrl?: string;
+  baggageAllowance?: string;
+  frequentFlyerNumber?: string;
+  bookingClassLetter?: string;
+  coPassengers?: string[];
 }
 
 export interface ParsedBooking {
@@ -130,6 +134,14 @@ export interface ParsedBooking {
   boardingGroup?: string;
   taxes?: string;
   fees?: string;
+  // Phase 1: New fields
+  baggageAllowance?: string;
+  frequentFlyerNumber?: string;
+  bookingClassLetter?: string;
+  coPassengers?: string[];
+  parserTemplate?: string;
+  parserConfidence?: number;
+  airlineNotice?: string;
   missing?: string[];
 }
 

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -141,7 +141,7 @@ export interface ParsedBooking {
   coPassengers?: string[];
   parserTemplate?: string;
   parserConfidence?: number;
-  airlineNotice?: string;
+  airlineNotice?: string; // Transient: not persisted to DB, UI-only notice when no template found
   missing?: string[];
 }
 


### PR DESCRIPTION
## Summary

- **Airline Template Engine**: JSON-basierte Templates mit CSS-Selektoren und sicheren Whitelist-Transforms (8 Airlines: LH, LX, OS, SN, FR, U2, EW, W6) — läuft vor LLM-Fallback
- **Airline Detector**: Erkennt Airline via From-Adresse, Subject-Pattern und HTML-Fingerprint mit sicherem Domain-Matching (kein Spoofing)
- **Template Registry**: Singleton mit eingebauten + gecachten Templates, täglichem GitHub-Sync und graceful Fallback
- **Training Recorder**: Speichert ParseTrainingLog-Einträge für Template-Hits/Misses und künftiges LLM Fine-Tuning
- **6 neue Datenbankfelder**: `baggageAllowance`, `frequentFlyerNumber`, `bookingClassLetter`, `coPassengers`, `parserTemplate`, `parserConfidence`
- **EmailImportTab**: Drag & Drop für .eml/.msg/.txt, Airline-Notice-Banner, Text-Paste-Fallback — Email ist jetzt erster Tab
- **TemplateStatusView**: In-App Übersicht der geladenen Templates mit GitHub-Link für Community-Beiträge
- **Security**: `new Function()` RCE-Risiko durch Whitelist-Transforms ersetzt; Domain-Spoofing in Airline-Detektor behoben

## Test Plan

- [ ] Backend `npx tsc --noEmit` — kein Fehler
- [ ] Frontend `npx tsc --noEmit` — kein Fehler
- [ ] Frontend `npx vitest --run` — 88 Tests pass (4 pre-existing VisModeSelector failures unrelated)
- [ ] Template-Tests: `backend/src/__tests__/templates/` — 10/10 pass
- [ ] Email-Import: .eml-Datei hochladen → Airline erkannt, Felder befüllt
- [ ] Kein Template → LLM-Fallback + gelbe Airline-Notice-Banner
- [ ] Settings → Template-Status zeigt 8 geladene Templates
- [ ] Prisma Migration erfolgreich: 6 neue Flight-Felder + ParseTrainingLog-Tabelle