### PR TITLE
fix: regex PNR matchAll — fehlender g-Flag (Email-Parse 500)

### DIFF
--- a/backend/src/services/parsers/text/regexParser.ts
+++ b/backend/src/services/parsers/text/regexParser.ts
@@ -433,7 +433,8 @@ export class RegexTextParser implements ITextParser {
   private extractSharedPNR(source: string): string | undefined {
     const sourceUpper = source.toUpperCase();
     const pnrFalsePositives = ['VIELEN', 'DANKEN', 'SEHREN', 'WICHTIG', 'BESTEN', 'GRUSS', 'GRUESSE', 'HERZLI', 'FREUND', 'BESTEN', 'SCHONEN', 'GUTEN', 'GUTER', 'GUTES', 'NEUEN', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE', 'SCHON', 'SCHONE', 'SCHONER', 'SCHONES', 'NEUE', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE'];
-    const pnrMatches = Array.from(sourceUpper.matchAll(PATTERNS.PNR));
+    const pnrPattern = /\b([A-Z0-9]{6})\b/g;
+    const pnrMatches = Array.from(sourceUpper.matchAll(pnrPattern));
     for (const match of pnrMatches) {
       const pnr = match[1];
       if (!pnrFalsePositives.includes(pnr) && /[0-9]/.test(pnr)) {
@@ -495,7 +496,7 @@ export class RegexTextParser implements ITextParser {
     // PNR - improved to avoid false matches like "VIELEN"
     // Common false positives (German words, common text)
     const pnrFalsePositives = ['VIELEN', 'DANKEN', 'SEHREN', 'WICHTIG', 'BESTEN', 'GRUSS', 'GRUESSE', 'HERZLI', 'FREUND', 'BESTEN', 'SCHONEN', 'GUTEN', 'GUTER', 'GUTES', 'NEUEN', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE', 'SCHON', 'SCHONE', 'SCHONER', 'SCHONES', 'NEUE', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE'];
-    const pnrMatches = Array.from(sourceUpper.matchAll(PATTERNS.PNR));
+    const pnrMatches = Array.from(sourceUpper.matchAll(/\b([A-Z0-9]{6})\b/g));
     for (const match of pnrMatches) {
       const pnr = match[1];
       // PNR should be alphanumeric, not all letters (common words)

--- a/backend/src/services/parsers/text/regexParser.ts
+++ b/backend/src/services/parsers/text/regexParser.ts
@@ -27,6 +27,14 @@ const CITY_TO_IATA: Record<string, string> = {
   budapest: 'BUD', istanbul: 'IST', athen: 'ATH', athens: 'ATH',
 };
 
+// PNR false positives (German words that match 6-char alphanumeric pattern)
+const PNR_FALSE_POSITIVES = new Set([
+  'VIELEN', 'DANKEN', 'SEHREN', 'WICHTIG', 'BESTEN', 'GRUSS', 'GRUESSE',
+  'HERZLI', 'FREUND', 'SCHONEN', 'GUTEN', 'GUTER', 'GUTES', 'NEUEN',
+  'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE',
+  'KLEIN', 'KLEINE', 'SCHON', 'SCHONE', 'SCHONER', 'SCHONES', 'NEUE',
+]);
+
 // Context-aware IATA code extraction patterns
 const IATA_CONTEXT_PATTERNS = [
   /(?:von|ab|from|dep(?:arture)?)\s+([A-Z]{3})/g,
@@ -69,24 +77,29 @@ export class RegexTextParser implements ITextParser {
   async parseEmail(subject: string, text: string, html?: string): Promise<ParsedBooking[]> {
     logger.info('[Regex Parser] Starting email parsing');
 
-    const source = [subject || '', text || '', this.extractText(html)].join('\n');
+    try {
+      const source = [subject || '', text || '', this.extractText(html)].join('\n');
 
-    // Try to extract multiple flights (round-trip, multi-leg)
-    const flights = this.parseMultipleFlights(source);
+      // Try to extract multiple flights (round-trip, multi-leg)
+      const flights = this.parseMultipleFlights(source);
 
-    logger.info(
-      {
-        flightCount: flights.length,
-        flights: flights.map(f => ({
-          flightNumber: f.flightNumber,
-          route: `${f.departureCode} → ${f.arrivalCode}`,
-          missing: f.missing.length,
-        })),
-      },
-      '[Regex Parser] Parsing complete'
-    );
+      logger.info(
+        {
+          flightCount: flights.length,
+          flights: flights.map(f => ({
+            flightNumber: f.flightNumber,
+            route: `${f.departureCode} → ${f.arrivalCode}`,
+            missing: f.missing.length,
+          })),
+        },
+        '[Regex Parser] Parsing complete'
+      );
 
-    return flights;
+      return flights;
+    } catch (error) {
+      logger.error({ error, subject }, '[Regex Parser] Unexpected error during parsing');
+      throw error;
+    }
   }
 
   /**
@@ -97,7 +110,8 @@ export class RegexTextParser implements ITextParser {
     try {
       const root = parse(html);
       return root.text || '';
-    } catch {
+    } catch (error) {
+      logger.warn({ error, htmlLength: html.length }, '[Regex Parser] HTML text extraction failed, proceeding without HTML content');
       return '';
     }
   }
@@ -428,20 +442,25 @@ export class RegexTextParser implements ITextParser {
   }
 
   /**
-   * Extract shared PNR (should be same for all flights)
+   * Find the first PNR candidate in an already-uppercased source string.
+   * A PNR is a 6-char alphanumeric token that contains at least one digit
+   * and is not a known German false-positive word.
    */
-  private extractSharedPNR(source: string): string | undefined {
-    const sourceUpper = source.toUpperCase();
-    const pnrFalsePositives = ['VIELEN', 'DANKEN', 'SEHREN', 'WICHTIG', 'BESTEN', 'GRUSS', 'GRUESSE', 'HERZLI', 'FREUND', 'BESTEN', 'SCHONEN', 'GUTEN', 'GUTER', 'GUTES', 'NEUEN', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE', 'SCHON', 'SCHONE', 'SCHONER', 'SCHONES', 'NEUE', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE'];
-    const pnrPattern = /\b([A-Z0-9]{6})\b/g;
-    const pnrMatches = Array.from(sourceUpper.matchAll(pnrPattern));
-    for (const match of pnrMatches) {
+  private findPNRInSource(sourceUpper: string): string | undefined {
+    for (const match of sourceUpper.matchAll(/\b([A-Z0-9]{6})\b/g)) {
       const pnr = match[1];
-      if (!pnrFalsePositives.includes(pnr) && /[0-9]/.test(pnr)) {
+      if (!PNR_FALSE_POSITIVES.has(pnr) && /[0-9]/.test(pnr)) {
         return pnr;
       }
     }
     return undefined;
+  }
+
+  /**
+   * Extract shared PNR (should be same for all flights)
+   */
+  private extractSharedPNR(source: string): string | undefined {
+    return this.findPNRInSource(source.toUpperCase());
   }
 
   /**
@@ -493,19 +512,11 @@ export class RegexTextParser implements ITextParser {
       }
     }
 
-    // PNR - improved to avoid false matches like "VIELEN"
-    // Common false positives (German words, common text)
-    const pnrFalsePositives = ['VIELEN', 'DANKEN', 'SEHREN', 'WICHTIG', 'BESTEN', 'GRUSS', 'GRUESSE', 'HERZLI', 'FREUND', 'BESTEN', 'SCHONEN', 'GUTEN', 'GUTER', 'GUTES', 'NEUEN', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE', 'SCHON', 'SCHONE', 'SCHONER', 'SCHONES', 'NEUE', 'NEUER', 'NEUES', 'ALTE', 'ALTEN', 'ALTES', 'GROSS', 'GROSSE', 'KLEIN', 'KLEINE'];
-    const pnrMatches = Array.from(sourceUpper.matchAll(/\b([A-Z0-9]{6})\b/g));
-    for (const match of pnrMatches) {
-      const pnr = match[1];
-      // PNR should be alphanumeric, not all letters (common words)
-      // And not in the false positives list
-      if (!pnrFalsePositives.includes(pnr) && /[0-9]/.test(pnr)) {
-        data.pnr = pnr;
-        data.bookingReference = pnr;
-        break;
-      }
+    // PNR - delegate to shared extraction logic
+    const pnr = this.findPNRInSource(sourceUpper);
+    if (pnr) {
+      data.pnr = pnr;
+      data.bookingReference = pnr;
     }
 
     // Airports


### PR DESCRIPTION
## Summary
- `PATTERNS.PNR` ist `/\b([A-Z0-9]{6})\b/` ohne `g`-Flag
- Wurde an zwei Stellen mit `String.prototype.matchAll()` aufgerufen — das wirft immer einen `TypeError` wenn kein `g`-Flag gesetzt ist
- Alle Parser schlugen dadurch fehl → 500 auf `/api/v1/parse-email`

## Root Cause
`regexParser.ts` Zeilen 436 + 499 riefen `matchAll(PATTERNS.PNR)` auf, aber `PATTERNS.PNR` hat kein `g`-Flag. `matchAll` erfordert zwingend ein globales RegExp.

## Fix
Beide Stellen verwenden jetzt `/\b([A-Z0-9]{6})\b/g` direkt (inline), da `PATTERNS.PNR` an anderen Stellen mit `.match()` korrekt ohne `g` genutzt wird.

## Test plan
- [ ] Email-Parse-Endpoint `/api/v1/parse-email` gibt keine 500 mehr zurück
- [ ] Regex-Parser verarbeitet Emails und extrahiert PNR korrekt
- [ ] `npx tsc --noEmit` im backend sauber

🤖 Generated with [Claude Code](https://claude.com/claude-code)