### PR TITLE
test: robustness improvements — Prisma cleanup, unit tests, minRouteCount fix

### DIFF
--- a/backend/prisma/migrations/20260403142615_remove_training_job_models/migration.sql
+++ b/backend/prisma/migrations/20260403142615_remove_training_job_models/migration.sql
@@ -1,0 +1,17 @@
+-- DropForeignKey
+ALTER TABLE "training_logs" DROP CONSTRAINT IF EXISTS "training_logs_training_job_id_fkey";
+
+-- DropIndex
+DROP INDEX IF EXISTS "training_jobs_status_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "training_logs_training_job_id_idx";
+
+-- DropIndex
+DROP INDEX IF EXISTS "training_logs_timestamp_idx";
+
+-- DropTable
+DROP TABLE IF EXISTS "training_logs";
+
+-- DropTable
+DROP TABLE IF EXISTS "training_jobs";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -353,40 +353,6 @@ model TrainingData {
   @@map("training_data")
 }
 
-model TrainingJob {
-  id              String    @id @default(uuid())
-  status          String // "pending" | "running" | "completed" | "failed"
-  trainingDataIds String[]  @map("training_data_ids") // Array of TrainingData IDs
-  modelName       String    @map("model_name") // z.B. "travstats-custom"
-  modelType       String    @default("combined") @map("model_type") // "email" | "vision" | "combined"
-  startedAt       DateTime? @map("started_at")
-  completedAt     DateTime? @map("completed_at")
-  errorMessage    String?   @map("error_message")
-  logFile         String?   @map("log_file") // Path to detailed log file
-  metrics         Json? // Training metrics (loss, accuracy, etc.)
-  createdAt       DateTime  @default(now()) @map("created_at")
-
-  logs TrainingLog[]
-
-  @@index([status])
-  @@map("training_jobs")
-}
-
-model TrainingLog {
-  id            String   @id @default(uuid())
-  trainingJobId String   @map("training_job_id")
-  level         String // "info" | "warn" | "error" | "debug"
-  message       String
-  metadata      Json? // Zusätzliche strukturierte Daten
-  timestamp     DateTime @default(now())
-
-  trainingJob TrainingJob @relation(fields: [trainingJobId], references: [id], onDelete: Cascade)
-
-  @@index([trainingJobId])
-  @@index([timestamp])
-  @@map("training_logs")
-}
-
 model AirportSeedingStatus {
   id                     String    @id @default(uuid())
   status                 String // "pending" | "running" | "completed" | "failed"

--- a/backend/src/__tests__/backupService.test.ts
+++ b/backend/src/__tests__/backupService.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// Mock prisma
+const mockBackupFindMany = jest.fn();
+const mockBackupFindUnique = jest.fn();
+const mockBackupDelete = jest.fn();
+
+jest.mock("../db", () => ({
+  prisma: {
+    backup: {
+      findMany: mockBackupFindMany,
+      findUnique: mockBackupFindUnique,
+      delete: mockBackupDelete,
+    },
+  },
+}));
+
+// Mock fs (imported as `import * as fs from 'fs'` in backupService)
+jest.mock("fs", () => ({
+  existsSync: jest.fn(),
+  mkdirSync: jest.fn(),
+  rmSync: jest.fn(),
+  statSync: jest.fn(),
+  createWriteStream: jest.fn(),
+  readFileSync: jest.fn(),
+  unlinkSync: jest.fn(),
+}));
+
+// Mock archiver to prevent native module issues (path-scurry) in test environment
+jest.mock("archiver", () => jest.fn());
+
+// Mock logger
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+// Mock database utility to avoid requiring real env vars at module load
+jest.mock("../utils/database", () => ({
+  DATABASE_URL: "postgresql://test:test@localhost:5432/test",
+}));
+
+// Import service after mocks are registered
+import { listBackups, getBackup, deleteBackup, cleanupOldBackups } from "../services/backupService";
+import * as fs from "fs";
+
+const mockExistsSync = fs.existsSync as jest.Mock;
+const mockRmSync = fs.rmSync as jest.Mock;
+
+const MOCK_BACKUP = {
+  id: "backup-1",
+  type: "full",
+  status: "completed",
+  backupPath: "/data/backups/backup-1/backup.tar.gz",
+  dbBackupPath: null,
+  filesBackupPath: null,
+  size: BigInt(1024),
+  retentionDays: 30,
+  startedAt: null,
+  completedAt: new Date("2026-01-01T00:05:00Z"),
+  errorMessage: null,
+  metadata: null,
+  syncedToCloud: false,
+  cloudSyncAt: null,
+  createdAt: new Date("2026-01-01T00:00:00Z"),
+  updatedAt: new Date("2026-01-01T00:05:00Z"),
+};
+
+describe("backupService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: directories/files do not exist (safe default)
+    mockExistsSync.mockReturnValue(false);
+  });
+
+  // ─── listBackups ───────────────────────────────────────────────────────────
+
+  describe("listBackups", () => {
+    it("returns backups ordered by createdAt desc", async () => {
+      const backups = [MOCK_BACKUP, { ...MOCK_BACKUP, id: "backup-2" }];
+      mockBackupFindMany.mockResolvedValue(backups);
+
+      const result = await listBackups();
+
+      expect(result).toEqual(backups);
+      expect(mockBackupFindMany).toHaveBeenCalledWith({
+        orderBy: { createdAt: "desc" },
+      });
+    });
+
+    it("returns empty array when no backups exist", async () => {
+      mockBackupFindMany.mockResolvedValue([]);
+
+      const result = await listBackups();
+
+      expect(result).toEqual([]);
+    });
+  });
+
+  // ─── getBackup ─────────────────────────────────────────────────────────────
+
+  describe("getBackup", () => {
+    it("returns backup with fileExists: true when file exists on disk", async () => {
+      mockBackupFindUnique.mockResolvedValue(MOCK_BACKUP);
+      mockExistsSync.mockReturnValue(true);
+
+      const result = await getBackup("backup-1");
+
+      expect(result).toEqual({ ...MOCK_BACKUP, fileExists: true });
+      expect(mockBackupFindUnique).toHaveBeenCalledWith({ where: { id: "backup-1" } });
+      expect(mockExistsSync).toHaveBeenCalledWith(MOCK_BACKUP.backupPath);
+    });
+
+    it("returns backup with fileExists: false when file does not exist on disk", async () => {
+      mockBackupFindUnique.mockResolvedValue(MOCK_BACKUP);
+      mockExistsSync.mockReturnValue(false);
+
+      const result = await getBackup("backup-1");
+
+      expect(result).toEqual({ ...MOCK_BACKUP, fileExists: false });
+    });
+
+    it("returns fileExists: false when backupPath is null", async () => {
+      const backupWithNullPath = { ...MOCK_BACKUP, backupPath: null };
+      mockBackupFindUnique.mockResolvedValue(backupWithNullPath);
+
+      const result = await getBackup("backup-1");
+
+      expect(result.fileExists).toBe(false);
+      // existsSync should not be called with null
+      expect(mockExistsSync).not.toHaveBeenCalled();
+    });
+
+    it("throws 'Backup not found' when backup does not exist in DB", async () => {
+      mockBackupFindUnique.mockResolvedValue(null);
+
+      await expect(getBackup("nonexistent-id")).rejects.toThrow("Backup not found");
+    });
+  });
+
+  // ─── deleteBackup ──────────────────────────────────────────────────────────
+
+  describe("deleteBackup", () => {
+    it("deletes backup directory and DB record when file exists", async () => {
+      mockBackupFindUnique.mockResolvedValue(MOCK_BACKUP);
+      // backupPath exists → existsSync returns true for both the file and the dir
+      mockExistsSync.mockReturnValue(true);
+
+      await deleteBackup("backup-1");
+
+      // Should delete the parent directory of backupPath
+      const expectedDir = "/data/backups/backup-1";
+      expect(mockRmSync).toHaveBeenCalledWith(expectedDir, { recursive: true, force: true });
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "backup-1" } });
+    });
+
+    it("skips rmSync when backupPath file does not exist on disk", async () => {
+      mockBackupFindUnique.mockResolvedValue(MOCK_BACKUP);
+      // file does not exist → existsSync returns false
+      mockExistsSync.mockReturnValue(false);
+
+      await deleteBackup("backup-1");
+
+      expect(mockRmSync).not.toHaveBeenCalled();
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "backup-1" } });
+    });
+
+    it("skips rmSync when backupPath is null", async () => {
+      const backupNoPath = { ...MOCK_BACKUP, backupPath: null };
+      mockBackupFindUnique.mockResolvedValue(backupNoPath);
+
+      await deleteBackup("backup-1");
+
+      expect(mockRmSync).not.toHaveBeenCalled();
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "backup-1" } });
+    });
+
+    it("skips directory rmSync when backup directory does not exist", async () => {
+      mockBackupFindUnique.mockResolvedValue(MOCK_BACKUP);
+      // backupPath itself exists but its parent dir check returns false
+      mockExistsSync
+        .mockReturnValueOnce(true)  // backup.backupPath exists
+        .mockReturnValueOnce(false); // backupDir does not exist
+
+      await deleteBackup("backup-1");
+
+      expect(mockRmSync).not.toHaveBeenCalled();
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "backup-1" } });
+    });
+
+    it("throws 'Backup not found' when backup does not exist in DB", async () => {
+      mockBackupFindUnique.mockResolvedValue(null);
+
+      await expect(deleteBackup("nonexistent-id")).rejects.toThrow("Backup not found");
+      expect(mockBackupDelete).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── cleanupOldBackups ─────────────────────────────────────────────────────
+
+  describe("cleanupOldBackups", () => {
+    it("deletes old completed backups and returns deleted count", async () => {
+      const oldBackup1 = { ...MOCK_BACKUP, id: "old-1" };
+      const oldBackup2 = { ...MOCK_BACKUP, id: "old-2" };
+      mockBackupFindMany.mockResolvedValue([oldBackup1, oldBackup2]);
+      // deleteBackup calls findUnique for each; return the corresponding backup
+      mockBackupFindUnique
+        .mockResolvedValueOnce(oldBackup1)
+        .mockResolvedValueOnce(oldBackup2);
+      mockExistsSync.mockReturnValue(false);
+
+      const count = await cleanupOldBackups();
+
+      expect(count).toBe(2);
+      expect(mockBackupDelete).toHaveBeenCalledTimes(2);
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "old-1" } });
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "old-2" } });
+    });
+
+    it("returns 0 when no old backups exist", async () => {
+      mockBackupFindMany.mockResolvedValue([]);
+
+      const count = await cleanupOldBackups();
+
+      expect(count).toBe(0);
+      expect(mockBackupDelete).not.toHaveBeenCalled();
+    });
+
+    it("queries only completed backups older than retention cutoff", async () => {
+      mockBackupFindMany.mockResolvedValue([]);
+
+      await cleanupOldBackups();
+
+      expect(mockBackupFindMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            status: "completed",
+            createdAt: expect.objectContaining({ lt: expect.any(Date) }),
+          }),
+        }),
+      );
+    });
+
+    it("continues deleting remaining backups if one deletion fails", async () => {
+      const failingBackup = { ...MOCK_BACKUP, id: "failing-1" };
+      const successBackup = { ...MOCK_BACKUP, id: "success-2" };
+      mockBackupFindMany.mockResolvedValue([failingBackup, successBackup]);
+
+      // First findUnique for failing backup returns null → deleteBackup throws
+      mockBackupFindUnique
+        .mockResolvedValueOnce(null)           // failing-1: not found → throws
+        .mockResolvedValueOnce(successBackup); // success-2: found → deletes
+      mockExistsSync.mockReturnValue(false);
+
+      const count = await cleanupOldBackups();
+
+      // Only the successful deletion is counted
+      expect(count).toBe(1);
+      expect(mockBackupDelete).toHaveBeenCalledTimes(1);
+      expect(mockBackupDelete).toHaveBeenCalledWith({ where: { id: "success-2" } });
+    });
+  });
+});

--- a/backend/src/__tests__/emailService.test.ts
+++ b/backend/src/__tests__/emailService.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+import nodemailer from "nodemailer";
+
+// Persistent mock transporter shared across all calls to createTransport
+const mockTransporter = {
+  sendMail: jest.fn(),
+  verify: jest.fn(),
+};
+
+// jest.mock is hoisted — factories run before any import statements
+jest.mock("nodemailer", () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn(),
+  },
+}));
+
+jest.mock("../db", () => ({
+  prisma: {
+    smtpConfig: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("../routes/admin/smtp", () => ({ SMTP_CONFIG_ID: 1 }));
+
+// Import service after mocks are registered
+import { sendFlightReminder, testSmtpConnection } from "../services/emailService";
+import { prisma } from "../db";
+
+const mockFindUnique = prisma.smtpConfig.findUnique as jest.Mock;
+const mockCreateTransport = nodemailer.createTransport as jest.Mock;
+
+const MOCK_FLIGHT = {
+  id: "flight-1",
+  flightNumber: "LH103",
+  depName: "Munich Airport",
+  depIata: "MUC",
+  arrName: "Frankfurt Airport",
+  arrIata: "FRA",
+  departureTime: new Date("2026-05-01T10:00:00Z"),
+};
+
+const MOCK_USER = { notificationEmail: "user@example.com" };
+
+const MOCK_SMTP_CONFIG = {
+  id: 1,
+  host: "smtp.example.com",
+  port: 587,
+  secure: false,
+  username: "user",
+  password: "pass",
+  fromEmail: "noreply@example.com",
+  fromName: "TravStats",
+  enabled: true,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+describe("emailService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Always return the same persistent transporter so we can inspect its mocks
+    mockCreateTransport.mockReturnValue(mockTransporter);
+  });
+
+  describe("sendFlightReminder", () => {
+    it("skips send when user has no notification email", async () => {
+      await sendFlightReminder(MOCK_FLIGHT, { notificationEmail: null }, 24);
+
+      expect(mockFindUnique).not.toHaveBeenCalled();
+      expect(mockTransporter.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("skips send when SMTP config is not found", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      await sendFlightReminder(MOCK_FLIGHT, MOCK_USER, 24);
+
+      expect(mockTransporter.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("skips send when SMTP is disabled", async () => {
+      mockFindUnique.mockResolvedValue({ ...MOCK_SMTP_CONFIG, enabled: false });
+
+      await sendFlightReminder(MOCK_FLIGHT, MOCK_USER, 24);
+
+      expect(mockTransporter.sendMail).not.toHaveBeenCalled();
+    });
+
+    it("sends email when SMTP is configured and enabled", async () => {
+      mockFindUnique.mockResolvedValue(MOCK_SMTP_CONFIG);
+      mockTransporter.sendMail.mockResolvedValue({ messageId: "msg-1" });
+
+      await sendFlightReminder(MOCK_FLIGHT, MOCK_USER, 24);
+
+      expect(mockTransporter.sendMail).toHaveBeenCalledTimes(1);
+      const callArgs = mockTransporter.sendMail.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.to).toBe("user@example.com");
+      expect(callArgs.subject).toContain("LH103");
+      expect(callArgs.subject).toContain("24h");
+      expect(callArgs.html).toContain("MUC");
+      expect(callArgs.html).toContain("FRA");
+    });
+
+    it("throws when sendMail fails", async () => {
+      mockFindUnique.mockResolvedValue(MOCK_SMTP_CONFIG);
+      mockTransporter.sendMail.mockRejectedValue(new Error("SMTP connection refused"));
+
+      await expect(sendFlightReminder(MOCK_FLIGHT, MOCK_USER, 24)).rejects.toThrow(
+        "SMTP connection refused"
+      );
+    });
+
+    it("uses flight number N/A when flightNumber is null", async () => {
+      mockFindUnique.mockResolvedValue(MOCK_SMTP_CONFIG);
+      mockTransporter.sendMail.mockResolvedValue({ messageId: "msg-1" });
+
+      await sendFlightReminder({ ...MOCK_FLIGHT, flightNumber: null }, MOCK_USER, 48);
+
+      const callArgs = mockTransporter.sendMail.mock.calls[0][0] as Record<string, unknown>;
+      expect(callArgs.subject).toContain("N/A");
+      expect(callArgs.subject).toContain("48h");
+    });
+  });
+
+  describe("testSmtpConnection", () => {
+    it("calls verify on the transporter", async () => {
+      mockTransporter.verify.mockResolvedValue(true);
+
+      await testSmtpConnection(MOCK_SMTP_CONFIG);
+
+      expect(mockTransporter.verify).toHaveBeenCalledTimes(1);
+    });
+
+    it("throws when verify fails", async () => {
+      mockTransporter.verify.mockRejectedValue(new Error("Connection refused"));
+
+      await expect(testSmtpConnection(MOCK_SMTP_CONFIG)).rejects.toThrow("Connection refused");
+    });
+
+    it("creates transporter with correct settings", async () => {
+      mockTransporter.verify.mockResolvedValue(true);
+
+      await testSmtpConnection({ ...MOCK_SMTP_CONFIG, port: 465, secure: true });
+
+      expect(mockCreateTransport).toHaveBeenCalledWith(
+        expect.objectContaining({
+          host: "smtp.example.com",
+          port: 465,
+          secure: true,
+        })
+      );
+    });
+  });
+});

--- a/backend/src/__tests__/parsers.factory.integration.test.ts
+++ b/backend/src/__tests__/parsers.factory.integration.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Integration tests for the parseEmail fallback chain in email.ts
+ *
+ * The 3-step chain:
+ *   Step 0: User-derived template (findMatchingTemplate + applyUserTemplate) — confidence ≥ 80 → return
+ *   Step 1: TemplateParser (checkAvailability + parseEmail) — confidence ≥ 30 → return
+ *   Step 2: LLM provider chain (getTextParserInstance per provider)
+ */
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+// ── Logger ────────────────────────────────────────────────────────────────────
+const mockLogger = {
+  info: jest.fn(),
+  warn: jest.fn(),
+  error: jest.fn(),
+  debug: jest.fn(),
+};
+
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: mockLogger,
+  parserFactoryLogger: mockLogger,
+  parserTextLogger: mockLogger,
+  httpLogger: mockLogger,
+  dbLogger: mockLogger,
+  parserLogger: mockLogger,
+  parserVisionLogger: mockLogger,
+  parserTextLogger2: mockLogger,
+  securityLogger: mockLogger,
+  systemLogger: mockLogger,
+}));
+
+// ── DB (Prisma) ───────────────────────────────────────────────────────────────
+jest.mock("../db", () => ({
+  prisma: {
+    userTemplate: { findMany: jest.fn() },
+    logConfig: { findUnique: jest.fn() },
+  },
+}));
+
+// ── Logging config ────────────────────────────────────────────────────────────
+jest.mock("../services/loggingConfig", () => ({
+  shouldLogParserOperations: jest.fn(),
+  getLoggingConfig: jest.fn(),
+}));
+
+// ── User template matcher ─────────────────────────────────────────────────────
+jest.mock("../services/parsers/userTemplates/matcher", () => ({
+  findMatchingTemplate: jest.fn(),
+  matchesFingerprint: jest.fn(),
+}));
+
+// ── User template engine ──────────────────────────────────────────────────────
+jest.mock("../services/parsers/userTemplates/engine", () => ({
+  applyUserTemplate: jest.fn(),
+}));
+
+// ── TemplateParser ────────────────────────────────────────────────────────────
+const mockTemplateParserCheckAvailability = jest.fn();
+const mockTemplateParserParseEmail = jest.fn();
+
+jest.mock("../services/parsers/text/templateParser", () => ({
+  TemplateParser: jest.fn().mockImplementation(() => ({
+    checkAvailability: mockTemplateParserCheckAvailability,
+    parseEmail: mockTemplateParserParseEmail,
+  })),
+}));
+
+// ── Providers ─────────────────────────────────────────────────────────────────
+jest.mock("../services/parsers/providers", () => ({
+  getTextParserInstance: jest.fn(),
+  getVisionParserInstance: jest.fn(),
+}));
+
+// ── Config (availability + cache) ────────────────────────────────────────────
+jest.mock("../services/parsers/config", () => ({
+  checkProviderAvailability: jest.fn(),
+  deleteAvailabilityCacheEntry: jest.fn(),
+  getDefaultTextFallbackChain: jest.fn().mockReturnValue(["regex"]),
+  getParserConfig: jest.fn(),
+}));
+
+// ── BoardingPass quality ──────────────────────────────────────────────────────
+jest.mock("../services/parsers/boardingPass", () => ({
+  calculateParserQuality: jest.fn(),
+  parseBoardingPass: jest.fn(),
+}));
+
+// ── Parser feedback ───────────────────────────────────────────────────────────
+jest.mock("../services/parserFeedback", () => ({
+  collectLowQualityFeedback: jest.fn().mockResolvedValue(undefined),
+  collectParserFeedback: jest.fn().mockResolvedValue(undefined),
+  collectCorrectionFeedback: jest.fn().mockResolvedValue(undefined),
+}));
+
+// ── Shared utils (extractFlightDataFromText used in post-processing) ──────────
+jest.mock("../services/parsers/shared/utils", () => ({
+  extractFlightDataFromText: jest.fn().mockReturnValue({}),
+}));
+
+// ── Import service AFTER mocks ────────────────────────────────────────────────
+import { parseEmail } from "../services/parsers/email";
+import { findMatchingTemplate } from "../services/parsers/userTemplates/matcher";
+import { applyUserTemplate } from "../services/parsers/userTemplates/engine";
+import { getTextParserInstance } from "../services/parsers/providers";
+import { checkProviderAvailability } from "../services/parsers/config";
+import { calculateParserQuality } from "../services/parsers/boardingPass";
+import { shouldLogParserOperations } from "../services/loggingConfig";
+import { TemplateParser } from "../services/parsers/text/templateParser";
+import type { TextProvider } from "../services/parsers/types";
+
+// ── Typed mock helpers ────────────────────────────────────────────────────────
+const mockFindMatchingTemplate = findMatchingTemplate as jest.MockedFunction<typeof findMatchingTemplate>;
+const mockApplyUserTemplate = applyUserTemplate as jest.MockedFunction<typeof applyUserTemplate>;
+const mockGetTextParserInstance = getTextParserInstance as jest.MockedFunction<typeof getTextParserInstance>;
+const mockCheckProviderAvailability = checkProviderAvailability as jest.MockedFunction<typeof checkProviderAvailability>;
+const mockCalculateParserQuality = calculateParserQuality as jest.MockedFunction<typeof calculateParserQuality>;
+const mockShouldLogParserOperations = shouldLogParserOperations as jest.MockedFunction<typeof shouldLogParserOperations>;
+
+// ── Base config used across tests ─────────────────────────────────────────────
+const BASE_CONFIG = {
+  visionProvider: "auto" as const,
+  textProvider: "auto" as const,
+  visionFallbacks: [] as never[],
+  textFallbacks: ["regex"] as TextProvider[],
+  userId: undefined,
+  openaiApiKey: undefined,
+  claudeApiKey: undefined,
+  ollamaModel: undefined,
+  allowUserApiKeys: false,
+  requireUserApiKeys: false,
+};
+
+const MOCK_FLIGHT = {
+  flightNumber: "LH400",
+  departureAirport: "FRA",
+  arrivalAirport: "JFK",
+  departureDate: "2026-05-01",
+  parserConfidence: 85,
+};
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+describe("parseEmail — fallback chain", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: no verbose logging
+    mockShouldLogParserOperations.mockResolvedValue(false);
+    // Default: quality above low-quality threshold to avoid LLM fallback logic
+    mockCalculateParserQuality.mockReturnValue(80);
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 1: User template with high confidence (≥80) → return immediately
+  // ────────────────────────────────────────────────────────────────────────────
+  it("returns user-template result immediately when confidence ≥ 80, skipping TemplateParser and LLM", async () => {
+    const config = { ...BASE_CONFIG, userId: "user-123" };
+
+    const mockTemplate = { name: "LH-template", patterns: {} };
+    mockFindMatchingTemplate.mockResolvedValue(mockTemplate as never);
+    mockApplyUserTemplate.mockReturnValue([MOCK_FLIGHT] as never);
+
+    const result = await parseEmail(
+      "Your Lufthansa booking confirmation",
+      "From: noreply@lufthansa.com\nFlight LH400",
+      undefined,
+      config
+    );
+
+    expect(result.provider).toBe("regex");
+    expect(result.fallbackUsed).toBe(false);
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0].flightNumber).toBe("LH400");
+
+    // TemplateParser must NOT have been instantiated (constructor not called)
+    expect(TemplateParser).not.toHaveBeenCalled();
+    // LLM provider chain must NOT have been invoked
+    expect(mockGetTextParserInstance).not.toHaveBeenCalled();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 2: No user templates → TemplateParser with confidence ≥ 30 → return
+  // ────────────────────────────────────────────────────────────────────────────
+  it("uses TemplateParser when no user template matches and confidence ≥ 30, skipping LLM chain", async () => {
+    // No userId → Step 0 skipped entirely
+    const config = { ...BASE_CONFIG };
+
+    const templateFlight = { ...MOCK_FLIGHT, parserConfidence: 90, parserTemplate: "lufthansa-v1" };
+    mockTemplateParserCheckAvailability.mockResolvedValue({ available: true });
+    mockTemplateParserParseEmail.mockResolvedValue([templateFlight] as never);
+
+    const result = await parseEmail(
+      "Booking confirmation",
+      "Flight LH400 departing FRA",
+      undefined,
+      config
+    );
+
+    expect(result.provider).toBe("regex");
+    expect(result.fallbackUsed).toBe(false);
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0].parserTemplate).toBe("lufthansa-v1");
+
+    // LLM chain must NOT have been invoked
+    expect(mockGetTextParserInstance).not.toHaveBeenCalled();
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 3: Template parser with confidence < 30 → falls through to LLM chain
+  // ────────────────────────────────────────────────────────────────────────────
+  it("falls through to LLM provider chain when TemplateParser confidence < 30", async () => {
+    const config = { ...BASE_CONFIG, textFallbacks: ["regex"] as TextProvider[] };
+
+    // Template parser returns low-confidence result
+    const lowConfFlight = { ...MOCK_FLIGHT, parserConfidence: 20 };
+    mockTemplateParserCheckAvailability.mockResolvedValue({ available: true });
+    mockTemplateParserParseEmail.mockResolvedValue([lowConfFlight] as never);
+
+    // LLM chain: regex provider available and returns a good flight
+    const regexFlight = { ...MOCK_FLIGHT, flightNumber: "BA200", parserConfidence: 75 };
+    const mockRegexParser = {
+      provider: "regex",
+      parseEmail: jest.fn<() => Promise<typeof regexFlight[]>>().mockResolvedValue([regexFlight]),
+      checkAvailability: jest.fn(),
+    };
+    mockGetTextParserInstance.mockReturnValue(mockRegexParser as never);
+    mockCheckProviderAvailability.mockResolvedValue({ available: true });
+    // Quality above 40 → no LLM quality-fallback triggered
+    mockCalculateParserQuality.mockReturnValue(75);
+
+    const result = await parseEmail(
+      "Booking confirmation",
+      "Flight BA200 departing LHR",
+      undefined,
+      config
+    );
+
+    expect(result.flights).toHaveLength(1);
+    expect(result.flights[0].flightNumber).toBe("BA200");
+    // regex provider was invoked
+    expect(mockGetTextParserInstance).toHaveBeenCalledWith("regex");
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 4: All providers fail → throws error
+  // ────────────────────────────────────────────────────────────────────────────
+  it("throws when all providers are unavailable", async () => {
+    const config = { ...BASE_CONFIG, textFallbacks: ["regex"] as TextProvider[] };
+
+    // Template parser unavailable
+    mockTemplateParserCheckAvailability.mockResolvedValue({
+      available: false,
+      reason: "No templates loaded",
+    });
+
+    // LLM chain: provider unavailable
+    const mockRegexParser = {
+      provider: "regex",
+      parseEmail: jest.fn(),
+      checkAvailability: jest.fn(),
+    };
+    mockGetTextParserInstance.mockReturnValue(mockRegexParser as never);
+    mockCheckProviderAvailability.mockResolvedValue({
+      available: false,
+      reason: "No API key",
+    });
+
+    await expect(
+      parseEmail(
+        "Booking confirmation",
+        "Flight BA200 departing LHR",
+        undefined,
+        config
+      )
+    ).rejects.toThrow("All text parsers failed");
+  });
+});

--- a/frontend/src/components/Stats.tsx
+++ b/frontend/src/components/Stats.tsx
@@ -27,7 +27,9 @@ export default function Stats({ filters = {} }: StatsProps): JSX.Element {
 
   const loadStats = async () => {
     try {
-      const { minRouteCount: _minRouteCount, ...apiFilters } = filters; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // minRouteCount is a map-only filter — not applied to API queries
+      const { minRouteCount: _mapOnly, ...apiFilters } = filters;
+      void _mapOnly;
       const hasBackendFilters = Object.keys(apiFilters).length > 0;
       // If filters are applied, calculate stats from filtered flights
       if (hasBackendFilters) {

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -187,7 +187,9 @@ export default function DashboardPage(): JSX.Element {
   const loadFlights = async () => {
     try {
       setLoadingMap(true);
-      const { minRouteCount: _mc, ...apiFilters } = filters; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // minRouteCount is a map-only filter — not applied to API queries
+      const { minRouteCount: _mapOnly, ...apiFilters } = filters;
+      void _mapOnly;
 
       // Load all flights by pagination (with safety limit)
       const MAX_PAGES = 100;
@@ -305,7 +307,9 @@ export default function DashboardPage(): JSX.Element {
         analyticsApi.track("export", { format });
       }
       if (format === "geojson") {
-        const { minRouteCount: _mc, ...apiFilters } = filters; // eslint-disable-line @typescript-eslint/no-unused-vars
+        // minRouteCount is a map-only filter — not applied to API queries
+        const { minRouteCount: _mapOnly, ...apiFilters } = filters;
+        void _mapOnly;
         const geoData = await flightsApi.getGeoJSON(apiFilters);
         const blob = new Blob([JSON.stringify(geoData, null, 2)], {
           type: "application/json",
@@ -318,7 +322,9 @@ export default function DashboardPage(): JSX.Element {
         URL.revokeObjectURL(url);
       } else {
         // CSV/PDF/KML export
-        const { minRouteCount: _mc, ...apiFilters } = filters; // eslint-disable-line @typescript-eslint/no-unused-vars
+        // minRouteCount is a map-only filter — not applied to API queries
+        const { minRouteCount: _mapOnly2, ...apiFilters } = filters;
+        void _mapOnly2;
         const data = await flightsApi.getAll(apiFilters);
 
         // Build rows with proper structure (not pre-joined)

--- a/frontend/src/pages/FlightsTablePage.tsx
+++ b/frontend/src/pages/FlightsTablePage.tsx
@@ -43,7 +43,9 @@ export default function FlightsTablePage(): JSX.Element {
   const loadFlights = async () => {
     try {
       setLoading(true);
-      const { minRouteCount: _mc, ...apiFilters } = filters; // eslint-disable-line @typescript-eslint/no-unused-vars
+      // minRouteCount is a map-only filter — not applied to API queries
+      const { minRouteCount: _mapOnly, ...apiFilters } = filters;
+      void _mapOnly;
       let allFlights: Flight[] = [];
       let offset = 0;
       const limit = API_LIMITS.MAX_PAGE_SIZE;


### PR DESCRIPTION
## Summary

- **Prisma cleanup**: Remove dead `TrainingJob` + `TrainingLog` models with migration SQL (`IF EXISTS` guards, correct FK/index drop order)
- **New unit tests**: Email service (9 tests), backup service (15 tests), parser factory integration (4 tests) — all using mocked dependencies, no DB required
- **minRouteCount fix**: Replace 5x `eslint-disable` comments with `void _mapOnly` + explanatory comment (map-only filter, not applied to API queries)

## Test Plan

- [ ] Backend: `cd backend && npx jest --forceExit` — new test suites all pass, 0 TS errors
- [ ] Frontend: `cd frontend && npx vitest --run` — 128/128 tests pass, 0 TS errors
- [ ] After DB is available: `npx prisma migrate deploy` applies `20260403142615_remove_training_job_models`