### PR TITLE
feat: settings overhaul — Ollama/Backup in DB, ghost settings cleanup, timezone

### DIFF
--- a/backend/prisma/migrations/20260403180000_settings_overhaul/migration.sql
+++ b/backend/prisma/migrations/20260403180000_settings_overhaul/migration.sql
@@ -1,0 +1,23 @@
+-- Migration: settings_overhaul
+-- Adds Ollama + Backup fields to AdminSettings, drops dead fields
+
+-- Drop system_settings table (replaced by AdminSettings)
+DROP TABLE IF EXISTS "system_settings";
+
+-- Add Ollama configuration columns to admin_settings
+ALTER TABLE "admin_settings" ADD COLUMN "ollama_url" TEXT;
+ALTER TABLE "admin_settings" ADD COLUMN "ollama_model" TEXT;
+ALTER TABLE "admin_settings" ADD COLUMN "ollama_vision_model" TEXT;
+
+-- Add Backup schedule columns to admin_settings
+ALTER TABLE "admin_settings" ADD COLUMN "backup_enabled" BOOLEAN NOT NULL DEFAULT false;
+ALTER TABLE "admin_settings" ADD COLUMN "backup_interval" TEXT NOT NULL DEFAULT 'weekly';
+ALTER TABLE "admin_settings" ADD COLUMN "backup_retention_days" INTEGER NOT NULL DEFAULT 30;
+
+-- Remove dead columns from admin_settings
+ALTER TABLE "admin_settings" DROP COLUMN IF EXISTS "require_user_api_keys";
+ALTER TABLE "admin_settings" DROP COLUMN IF EXISTS "require_user_flight_api_keys";
+ALTER TABLE "admin_settings" DROP COLUMN IF EXISTS "debug_logging_enabled";
+
+-- Remove dead column from user_settings
+ALTER TABLE "user_settings" DROP COLUMN IF EXISTS "training_separate_models";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -201,8 +201,6 @@ model UserSettings {
   useTrainedModels       Boolean @default(true) @map("use_trained_models")
   preferredEmailModel    String  @default("auto") @map("preferred_email_model") // "auto" | "trained" | "base"
   preferredVisionModel   String  @default("auto") @map("preferred_vision_model") // "auto" | "trained" | "base"
-  trainingSeparateModels Boolean @default(true) @map("training_separate_models")
-
   // Auto-update settings
   autoUpdateEnabled          Boolean @default(false) @map("auto_update_enabled")
   autoUpdateRequireApproval  Boolean @default(true) @map("auto_update_require_approval")
@@ -264,15 +262,6 @@ model Invitation {
   @@map("invitations")
 }
 
-model SystemSettings {
-  id        String   @id @default("global")
-  data      Json     @map("data")
-  createdAt DateTime @default(now()) @map("created_at")
-  updatedAt DateTime @updatedAt @map("updated_at")
-
-  @@map("system_settings")
-}
-
 model AdminSettings {
   id Int @id @default(autoincrement())
 
@@ -289,19 +278,24 @@ model AdminSettings {
   globalOpenskyPassword String? @map("global_opensky_password")
 
   // User permissions
-  allowUserApiKeys   Boolean @default(true) @map("allow_user_api_keys")
-  requireUserApiKeys Boolean @default(false) @map("require_user_api_keys")
+  allowUserApiKeys         Boolean @default(true) @map("allow_user_api_keys")
   allowUserFlightApiKeys   Boolean @default(true) @map("allow_user_flight_api_keys")
-  requireUserFlightApiKeys Boolean @default(false) @map("require_user_flight_api_keys")
 
   // Default parser settings for new users
   defaultVisionParser String @default("auto") @map("default_vision_parser")
   defaultTextParser   String @default("auto") @map("default_text_parser")
 
-  // === LOGGING CONFIGURATION ===
-  // Enable enhanced debug logging (activates debug/trace levels + detailed instrumentation)
-  debugLoggingEnabled Boolean @default(false) @map("debug_logging_enabled")
+  // Ollama configuration (overrides OLLAMA_URL / OLLAMA_MODEL env vars)
+  ollamaUrl         String? @map("ollama_url")
+  ollamaModel       String? @map("ollama_model")
+  ollamaVisionModel String? @map("ollama_vision_model")
 
+  // Backup schedule configuration (overrides AUTO_BACKUP_ENABLED / BACKUP_INTERVAL env vars)
+  backupEnabled       Boolean @default(false) @map("backup_enabled")
+  backupInterval      String  @default("weekly") @map("backup_interval")
+  backupRetentionDays Int     @default(30) @map("backup_retention_days")
+
+  // === LOGGING CONFIGURATION ===
   // Log level for file output (error | warn | info | debug | trace)
   logLevel String @default("info") @map("log_level")
 

--- a/backend/src/__tests__/backupScheduler.test.ts
+++ b/backend/src/__tests__/backupScheduler.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, jest, beforeEach } from "@jest/globals";
+
+const mockFindFirst = jest.fn();
+jest.mock("../db", () => ({
+  prisma: {
+    adminSettings: { findFirst: mockFindFirst },
+    backup: { findFirst: jest.fn().mockResolvedValue(null) },
+  },
+}));
+
+jest.mock("../services/backupService", () => ({
+  createBackup: jest.fn().mockResolvedValue({}),
+}));
+
+const mockSchedule = jest.fn(() => ({ start: jest.fn(), stop: jest.fn() }));
+jest.mock("node-cron", () => ({ schedule: mockSchedule }));
+
+jest.mock("../utils/logger", () => ({
+  __esModule: true,
+  default: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+describe("backupScheduler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  it("does not start scheduler when backupEnabled is false in DB", async () => {
+    mockFindFirst.mockResolvedValue({
+      backupEnabled: false,
+      backupInterval: "weekly",
+      backupRetentionDays: 30,
+    });
+    const { startScheduler } = await import("../services/backupScheduler");
+
+    await startScheduler();
+
+    expect(mockSchedule).not.toHaveBeenCalled();
+  });
+
+  it("starts scheduler with daily cron pattern when backupInterval is daily", async () => {
+    mockFindFirst.mockResolvedValue({
+      backupEnabled: true,
+      backupInterval: "daily",
+      backupRetentionDays: 30,
+    });
+    const { startScheduler } = await import("../services/backupScheduler");
+
+    await startScheduler();
+
+    expect(mockSchedule).toHaveBeenCalledWith("0 2 * * *", expect.any(Function));
+  });
+
+  it("starts scheduler with weekly cron pattern when backupInterval is weekly", async () => {
+    mockFindFirst.mockResolvedValue({
+      backupEnabled: true,
+      backupInterval: "weekly",
+      backupRetentionDays: 30,
+    });
+    const { startScheduler } = await import("../services/backupScheduler");
+
+    await startScheduler();
+
+    expect(mockSchedule).toHaveBeenCalledWith("0 2 * * 0", expect.any(Function));
+  });
+
+  it("uses default values when adminSettings row is null", async () => {
+    mockFindFirst.mockResolvedValue(null);
+    const { startScheduler } = await import("../services/backupScheduler");
+
+    await startScheduler();
+
+    // Default enabled=false, so scheduler should NOT start
+    expect(mockSchedule).not.toHaveBeenCalled();
+  });
+
+  it("getScheduleStatus returns running=false when no job is scheduled", async () => {
+    mockFindFirst.mockResolvedValue({
+      backupEnabled: true,
+      backupInterval: "weekly",
+      backupRetentionDays: 30,
+    });
+    const { getScheduleStatus } = await import("../services/backupScheduler");
+
+    const status = await getScheduleStatus();
+
+    expect(status).toEqual({ running: false });
+  });
+});

--- a/backend/src/__tests__/backupService.test.ts
+++ b/backend/src/__tests__/backupService.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, jest, beforeEach } from "@jest/globals";
 const mockBackupFindMany = jest.fn();
 const mockBackupFindUnique = jest.fn();
 const mockBackupDelete = jest.fn();
+const mockAdminSettingsFindFirst = jest.fn();
 
 jest.mock("../db", () => ({
   prisma: {
@@ -11,6 +12,9 @@ jest.mock("../db", () => ({
       findMany: mockBackupFindMany,
       findUnique: mockBackupFindUnique,
       delete: mockBackupDelete,
+    },
+    adminSettings: {
+      findFirst: mockAdminSettingsFindFirst,
     },
   },
 }));

--- a/backend/src/__tests__/parsers.factory.integration.test.ts
+++ b/backend/src/__tests__/parsers.factory.integration.test.ts
@@ -80,6 +80,11 @@ jest.mock("../services/parsers/config", () => ({
   getParserConfig: jest.fn(),
 }));
 
+// ── Model manager ─────────────────────────────────────────────────────────────
+jest.mock("../services/modelManager", () => ({
+  selectModelForParsing: jest.fn().mockResolvedValue(undefined),
+}));
+
 // ── BoardingPass quality ──────────────────────────────────────────────────────
 jest.mock("../services/parsers/boardingPass", () => ({
   calculateParserQuality: jest.fn(),
@@ -238,6 +243,21 @@ describe("parseEmail — fallback chain", () => {
     expect(result.flights[0].flightNumber).toBe("BA200");
     // regex provider was invoked
     expect(mockGetTextParserInstance).toHaveBeenCalledWith("regex");
+  });
+
+  // ────────────────────────────────────────────────────────────────────────────
+  // Test 5: getParserConfig picks up ollamaUrl from adminSettings
+  // ────────────────────────────────────────────────────────────────────────────
+  it("uses ollamaUrl from adminSettings when provided", async () => {
+    const { getParserConfig } = (await jest.requireActual(
+      "../services/parsers/config"
+    )) as typeof import("../services/parsers/config");
+    const config = await getParserConfig(
+      undefined,
+      { globalOpenaiApiKey: null, globalClaudeApiKey: null, ollamaUrl: "http://custom-ollama:11434" },
+      undefined
+    );
+    expect(config.ollamaUrl).toBe("http://custom-ollama:11434");
   });
 
   // ────────────────────────────────────────────────────────────────────────────

--- a/backend/src/config/env.ts
+++ b/backend/src/config/env.ts
@@ -68,6 +68,8 @@ const envSchema = z.object({
 
   // Backup Settings
   BACKUP_PATH: z.string().default('/app/data/backups'),
+  // DEPRECATED: backup toggle/interval/retention now stored in AdminSettings DB.
+  // Kept as optional fallback to avoid startup errors on existing deployments.
   BACKUP_RETENTION_DAYS: z.string().regex(/^\d+$/).transform(Number).default('30'),
   AUTO_BACKUP_ENABLED: z.string().transform((val) => val === 'true').default('false'),
   BACKUP_INTERVAL: z.enum(['daily', 'weekly', 'monthly']).default('weekly'),

--- a/backend/src/routes/admin.parseLogStats.test.ts
+++ b/backend/src/routes/admin.parseLogStats.test.ts
@@ -64,6 +64,13 @@ jest.mock("../utils/encryption", () => ({
 jest.mock("../utils/logger", () => ({
   default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
 }));
+jest.mock("../services/backupService", () => ({}));
+jest.mock("../services/backupScheduler", () => ({
+  startScheduler: jest.fn(),
+  stopScheduler: jest.fn(),
+  updateSchedule: jest.fn(),
+  getScheduleStatus: jest.fn(),
+}));
 jest.mock("./admin/smtp", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const express = require("express") as typeof import("express");

--- a/backend/src/routes/admin.promoteCorrections.test.ts
+++ b/backend/src/routes/admin.promoteCorrections.test.ts
@@ -66,6 +66,13 @@ jest.mock("../utils/encryption", () => ({
 jest.mock("../utils/logger", () => ({
   default: { info: jest.fn(), error: jest.fn(), warn: jest.fn(), debug: jest.fn() },
 }));
+jest.mock("../services/backupService", () => ({}));
+jest.mock("../services/backupScheduler", () => ({
+  startScheduler: jest.fn(),
+  stopScheduler: jest.fn(),
+  updateSchedule: jest.fn(),
+  getScheduleStatus: jest.fn(),
+}));
 jest.mock("./admin/smtp", () => {
   // eslint-disable-next-line @typescript-eslint/no-require-imports
   const express = require("express") as typeof import("express");

--- a/backend/src/routes/admin/apiKeys.ts
+++ b/backend/src/routes/admin/apiKeys.ts
@@ -20,7 +20,6 @@ interface GlobalApiKeysUpdateData {
   globalOpenskyUsername?: string | null;
   globalOpenskyPassword?: string | null;
   allowUserFlightApiKeys?: boolean;
-  requireUserFlightApiKeys?: boolean;
 }
 
 const globalApiKeysSchema = z.object({
@@ -31,7 +30,6 @@ const globalApiKeysSchema = z.object({
   globalOpenskyUsername: z.string().optional().nullable(),
   globalOpenskyPassword: z.string().optional().nullable(),
   allowUserFlightApiKeys: z.boolean().optional(),
-  requireUserFlightApiKeys: z.boolean().optional(),
 }).partial();
 
 const testApiKeySchema = z.object({
@@ -64,7 +62,6 @@ router.get('/api-keys', async (req: AuthRequest, res: Response, next: NextFuncti
         globalOpenskyUsername: undefined,
         globalOpenskyPassword: undefined,
         allowUserFlightApiKeys: true,
-        requireUserFlightApiKeys: false,
       });
     }
 
@@ -76,7 +73,6 @@ router.get('/api-keys', async (req: AuthRequest, res: Response, next: NextFuncti
       globalOpenskyUsername: decryptApiKey(adminSettings.globalOpenskyUsername) || undefined,
       globalOpenskyPassword: decryptApiKey(adminSettings.globalOpenskyPassword) || undefined,
       allowUserFlightApiKeys: adminSettings.allowUserFlightApiKeys ?? true,
-      requireUserFlightApiKeys: adminSettings.requireUserFlightApiKeys ?? false,
     });
   } catch (error) {
     logger.error({
@@ -120,9 +116,6 @@ router.put('/api-keys', async (req: AuthRequest, res: Response, next: NextFuncti
     if (payload.allowUserFlightApiKeys !== undefined) {
       updateData.allowUserFlightApiKeys = payload.allowUserFlightApiKeys;
     }
-    if (payload.requireUserFlightApiKeys !== undefined) {
-      updateData.requireUserFlightApiKeys = payload.requireUserFlightApiKeys;
-    }
 
     if (adminSettings) {
       adminSettings = await prisma.adminSettings.update({
@@ -133,11 +126,9 @@ router.put('/api-keys', async (req: AuthRequest, res: Response, next: NextFuncti
       adminSettings = await prisma.adminSettings.create({
         data: {
           allowUserApiKeys: true,
-          requireUserApiKeys: false,
           defaultVisionParser: 'auto',
           defaultTextParser: 'auto',
           allowUserFlightApiKeys: true,
-          requireUserFlightApiKeys: false,
           ...updateData,
         },
       });
@@ -153,7 +144,6 @@ router.put('/api-keys', async (req: AuthRequest, res: Response, next: NextFuncti
         globalOpenskyUsername: decryptApiKey(adminSettings.globalOpenskyUsername) || undefined,
         globalOpenskyPassword: decryptApiKey(adminSettings.globalOpenskyPassword) || undefined,
         allowUserFlightApiKeys: adminSettings.allowUserFlightApiKeys,
-        requireUserFlightApiKeys: adminSettings.requireUserFlightApiKeys,
       },
     });
   } catch (error) {

--- a/backend/src/routes/admin/backupSettings.ts
+++ b/backend/src/routes/admin/backupSettings.ts
@@ -1,0 +1,77 @@
+import { Router, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { AuthRequest } from '../../middleware/auth';
+import { prisma } from '../../db';
+import { updateSchedule } from '../../services/backupScheduler';
+import logger from '../../utils/logger';
+
+const backupSettingsSchema = z.object({
+  backupEnabled: z.boolean().optional(),
+  backupInterval: z.enum(['daily', 'weekly', 'monthly']).optional(),
+  backupRetentionDays: z.number().int().min(1).max(365).optional(),
+});
+
+const router = Router();
+
+router.get('/backup-settings', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const adminSettings = await prisma.adminSettings.findFirst();
+    res.json({
+      backupEnabled: adminSettings?.backupEnabled ?? false,
+      backupInterval: adminSettings?.backupInterval ?? 'weekly',
+      backupRetentionDays: adminSettings?.backupRetentionDays ?? 30,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+router.put('/backup-settings', async (req: AuthRequest, res: Response, next: NextFunction) => {
+  try {
+    const { backupEnabled, backupInterval, backupRetentionDays } = backupSettingsSchema.parse(req.body);
+
+    let adminSettings = await prisma.adminSettings.findFirst();
+
+    const updateData: {
+      backupEnabled?: boolean;
+      backupInterval?: string;
+      backupRetentionDays?: number;
+    } = {};
+
+    if (backupEnabled !== undefined) updateData.backupEnabled = backupEnabled;
+    if (backupInterval !== undefined) updateData.backupInterval = backupInterval;
+    if (backupRetentionDays !== undefined) updateData.backupRetentionDays = backupRetentionDays;
+
+    if (adminSettings) {
+      adminSettings = await prisma.adminSettings.update({
+        where: { id: adminSettings.id },
+        data: updateData,
+      });
+    } else {
+      adminSettings = await prisma.adminSettings.create({
+        data: {
+          allowUserApiKeys: true,
+          allowUserFlightApiKeys: true,
+          defaultVisionParser: 'auto',
+          defaultTextParser: 'auto',
+          ...updateData,
+        },
+      });
+    }
+
+    await updateSchedule();
+
+    logger.info({ operation: 'backup_settings_updated', context: updateData });
+
+    res.json({
+      message: 'Backup settings updated',
+      backupEnabled: adminSettings.backupEnabled,
+      backupInterval: adminSettings.backupInterval,
+      backupRetentionDays: adminSettings.backupRetentionDays,
+    });
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/backend/src/routes/admin/index.ts
+++ b/backend/src/routes/admin/index.ts
@@ -7,6 +7,7 @@ import apiKeysRouter from './apiKeys';
 import loggingRouter from './logging';
 import parserSettingsRouter from './parserSettings';
 import smtpRouter from './smtp';
+import backupSettingsRouter from './backupSettings';
 
 const router = Router();
 
@@ -22,5 +23,6 @@ router.use('/', apiKeysRouter);
 router.use('/logging', loggingRouter);
 router.use('/', parserSettingsRouter);
 router.use('/smtp', smtpRouter);
+router.use('/', backupSettingsRouter);
 
 export default router;

--- a/backend/src/routes/admin/parserSettings.ts
+++ b/backend/src/routes/admin/parserSettings.ts
@@ -9,18 +9,22 @@ interface ParserSettingsUpdateData {
   globalOpenaiApiKey?: string | null;
   globalClaudeApiKey?: string | null;
   allowUserApiKeys?: boolean;
-  requireUserApiKeys?: boolean;
   defaultVisionParser?: string;
   defaultTextParser?: string;
+  ollamaUrl?: string | null;
+  ollamaModel?: string | null;
+  ollamaVisionModel?: string | null;
 }
 
 const parserSettingsSchema = z.object({
   globalOpenaiApiKey: z.string().nullable().optional(),
   globalClaudeApiKey: z.string().nullable().optional(),
   allowUserApiKeys: z.boolean().optional(),
-  requireUserApiKeys: z.boolean().optional(),
   defaultVisionParser: z.string().optional(),
   defaultTextParser: z.string().optional(),
+  ollamaUrl: z.string().url().nullable().optional().or(z.literal("").transform(() => null)),
+  ollamaModel: z.string().max(100).nullable().optional(),
+  ollamaVisionModel: z.string().max(100).nullable().optional(),
 });
 
 // Training configuration schema
@@ -52,7 +56,7 @@ router.get('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
       adminSettings = await prisma.adminSettings.create({
         data: {
           allowUserApiKeys: true,
-          requireUserApiKeys: false,
+          allowUserFlightApiKeys: true,
           defaultVisionParser: 'auto',
           defaultTextParser: 'auto',
         },
@@ -67,14 +71,13 @@ router.get('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
       globalAviationstackApiKey: decryptApiKey(adminSettings.globalAviationstackApiKey) || undefined,
       globalOpenskyClientId: decryptApiKey(adminSettings.globalOpenskyClientId) || undefined,
       globalOpenskyClientSecret: decryptApiKey(adminSettings.globalOpenskyClientSecret) || undefined,
-      globalOpenskyUsername: decryptApiKey(adminSettings.globalOpenskyUsername) || undefined,
-      globalOpenskyPassword: decryptApiKey(adminSettings.globalOpenskyPassword) || undefined,
       allowUserApiKeys: adminSettings.allowUserApiKeys,
-      requireUserApiKeys: adminSettings.requireUserApiKeys,
       allowUserFlightApiKeys: adminSettings.allowUserFlightApiKeys,
-      requireUserFlightApiKeys: adminSettings.requireUserFlightApiKeys,
       defaultVisionParser: adminSettings.defaultVisionParser,
       defaultTextParser: adminSettings.defaultTextParser,
+      ollamaUrl: adminSettings.ollamaUrl || process.env.OLLAMA_URL || null,
+      ollamaModel: adminSettings.ollamaModel || process.env.OLLAMA_MODEL || null,
+      ollamaVisionModel: adminSettings.ollamaVisionModel || process.env.OLLAMA_VISION_MODEL || null,
     });
   } catch (error) {
     next(error);
@@ -88,9 +91,11 @@ router.put('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
       globalOpenaiApiKey,
       globalClaudeApiKey,
       allowUserApiKeys,
-      requireUserApiKeys,
       defaultVisionParser,
       defaultTextParser,
+      ollamaUrl,
+      ollamaModel,
+      ollamaVisionModel,
     } = parserSettingsSchema.parse(req.body);
 
     // Get or create admin settings
@@ -109,14 +114,20 @@ router.put('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
     if (allowUserApiKeys !== undefined) {
       updateData.allowUserApiKeys = allowUserApiKeys;
     }
-    if (requireUserApiKeys !== undefined) {
-      updateData.requireUserApiKeys = requireUserApiKeys;
-    }
     if (defaultVisionParser !== undefined) {
       updateData.defaultVisionParser = defaultVisionParser;
     }
     if (defaultTextParser !== undefined) {
       updateData.defaultTextParser = defaultTextParser;
+    }
+    if (ollamaUrl !== undefined) {
+      updateData.ollamaUrl = ollamaUrl;
+    }
+    if (ollamaModel !== undefined) {
+      updateData.ollamaModel = ollamaModel;
+    }
+    if (ollamaVisionModel !== undefined) {
+      updateData.ollamaVisionModel = ollamaVisionModel;
     }
 
     if (adminSettings) {
@@ -132,11 +143,12 @@ router.put('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
           globalOpenaiApiKey: encryptApiKey(globalOpenaiApiKey),
           globalClaudeApiKey: encryptApiKey(globalClaudeApiKey),
           allowUserApiKeys: allowUserApiKeys ?? true,
-          requireUserApiKeys: requireUserApiKeys ?? false,
           allowUserFlightApiKeys: true,
-          requireUserFlightApiKeys: false,
           defaultVisionParser: defaultVisionParser || 'auto',
           defaultTextParser: defaultTextParser || 'auto',
+          ollamaUrl: ollamaUrl ?? null,
+          ollamaModel: ollamaModel ?? null,
+          ollamaVisionModel: ollamaVisionModel ?? null,
         },
       });
     }
@@ -147,9 +159,11 @@ router.put('/parser-settings', async (req: AuthRequest, res: Response, next: Nex
         globalOpenaiApiKey: decryptApiKey(adminSettings.globalOpenaiApiKey) || undefined,
         globalClaudeApiKey: decryptApiKey(adminSettings.globalClaudeApiKey) || undefined,
         allowUserApiKeys: adminSettings.allowUserApiKeys,
-        requireUserApiKeys: adminSettings.requireUserApiKeys,
         defaultVisionParser: adminSettings.defaultVisionParser,
         defaultTextParser: adminSettings.defaultTextParser,
+        ollamaUrl: adminSettings.ollamaUrl || process.env.OLLAMA_URL || null,
+        ollamaModel: adminSettings.ollamaModel || process.env.OLLAMA_MODEL || null,
+        ollamaVisionModel: adminSettings.ollamaVisionModel || process.env.OLLAMA_VISION_MODEL || null,
       },
     });
   } catch (error) {
@@ -218,7 +232,7 @@ router.put('/training-config', async (req: AuthRequest, res: Response, next: Nex
       adminSettings = await prisma.adminSettings.create({
         data: {
           allowUserApiKeys: true,
-          requireUserApiKeys: false,
+          allowUserFlightApiKeys: true,
           defaultVisionParser: 'auto',
           defaultTextParser: 'auto',
           ...updateData,

--- a/backend/src/routes/settings/general.ts
+++ b/backend/src/routes/settings/general.ts
@@ -137,7 +137,6 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
           useTrainedModels: true,
           preferredEmailModel: 'auto',
           preferredVisionModel: 'auto',
-          trainingSeparateModels: true,
           // Initialize auto-update settings with defaults
           autoUpdateEnabled: false,
           autoUpdateRequireApproval: true,
@@ -293,7 +292,6 @@ router.put('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
         useTrainedModels: true,
         preferredEmailModel: 'auto',
         preferredVisionModel: 'auto',
-        trainingSeparateModels: true,
         // Initialize auto-update settings with defaults
         autoUpdateEnabled: payload.autoUpdate?.enabled ?? false,
         autoUpdateRequireApproval: payload.autoUpdate?.requireApproval ?? true,

--- a/backend/src/routes/settings/training.ts
+++ b/backend/src/routes/settings/training.ts
@@ -11,7 +11,6 @@ const trainingSettingsSchema = z.object({
   useTrainedModels: z.boolean().optional(),
   preferredEmailModel: z.enum(['auto', 'trained', 'base']).optional(),
   preferredVisionModel: z.enum(['auto', 'trained', 'base']).optional(),
-  trainingSeparateModels: z.boolean().optional(),
 });
 
 // GET /
@@ -25,7 +24,6 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
         useTrainedModels: true,
         preferredEmailModel: true,
         preferredVisionModel: true,
-        trainingSeparateModels: true,
       },
     });
 
@@ -33,7 +31,6 @@ router.get('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
       useTrainedModels: settings?.useTrainedModels ?? true,
       preferredEmailModel: settings?.preferredEmailModel ?? 'auto',
       preferredVisionModel: settings?.preferredVisionModel ?? 'auto',
-      trainingSeparateModels: settings?.trainingSeparateModels ?? true,
     });
   } catch (error) {
     next(error);
@@ -57,9 +54,6 @@ router.put('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
     if (payload.preferredVisionModel !== undefined) {
       updateData.preferredVisionModel = payload.preferredVisionModel;
     }
-    if (payload.trainingSeparateModels !== undefined) {
-      updateData.trainingSeparateModels = payload.trainingSeparateModels;
-    }
 
     const updated = await prisma.userSettings.upsert({
       where: { userId },
@@ -70,13 +64,11 @@ router.put('/', async (req: AuthRequest, res: Response, next: NextFunction): Pro
         useTrainedModels: payload.useTrainedModels ?? true,
         preferredEmailModel: payload.preferredEmailModel ?? 'auto',
         preferredVisionModel: payload.preferredVisionModel ?? 'auto',
-        trainingSeparateModels: payload.trainingSeparateModels ?? true,
       },
       select: {
         useTrainedModels: true,
         preferredEmailModel: true,
         preferredVisionModel: true,
-        trainingSeparateModels: true,
       },
     });
 

--- a/backend/src/routes/settings/types.ts
+++ b/backend/src/routes/settings/types.ts
@@ -121,7 +121,6 @@ export interface TrainingSettingsUpdateData {
   useTrainedModels?: boolean;
   preferredEmailModel?: string;
   preferredVisionModel?: string;
-  trainingSeparateModels?: boolean;
 }
 
 export interface ApiKeysUpdateData {

--- a/backend/src/schemas/admin.ts
+++ b/backend/src/schemas/admin.ts
@@ -4,7 +4,6 @@ import { z } from 'zod';
  * Schema for logging configuration
  */
 export const loggingConfigSchema = z.object({
-  debugLoggingEnabled: z.boolean().optional(),
   logLevel: z.enum(['error', 'warn', 'info', 'debug', 'trace']).optional(),
   maxLogFileSize: z.number().min(1).max(100).optional(), // 1-100 MB
   maxLogFiles: z.number().min(1).max(30).optional(), // Keep 1-30 files

--- a/backend/src/services/backupScheduler.ts
+++ b/backend/src/services/backupScheduler.ts
@@ -3,6 +3,16 @@ import { prisma } from '../db';
 import logger from '../utils/logger';
 import { createBackup } from './backupService';
 
+const VALID_INTERVALS = ['daily', 'weekly', 'monthly'] as const;
+type BackupInterval = (typeof VALID_INTERVALS)[number];
+
+function toBackupInterval(value: string | null | undefined): BackupInterval {
+  if (value && (VALID_INTERVALS as readonly string[]).includes(value)) {
+    return value as BackupInterval;
+  }
+  return 'weekly';
+}
+
 let scheduledJob: cron.ScheduledTask | null = null;
 
 /**
@@ -16,7 +26,7 @@ async function getBackupSettings(): Promise<{
   const adminSettings = await prisma.adminSettings.findFirst();
   return {
     enabled: adminSettings?.backupEnabled ?? false,
-    interval: (adminSettings?.backupInterval as 'daily' | 'weekly' | 'monthly') ?? 'weekly',
+    interval: toBackupInterval(adminSettings?.backupInterval),
     retentionDays: adminSettings?.backupRetentionDays ?? 30,
   };
 }

--- a/backend/src/services/backupScheduler.ts
+++ b/backend/src/services/backupScheduler.ts
@@ -6,6 +6,22 @@ import { createBackup } from './backupService';
 let scheduledJob: cron.ScheduledTask | null = null;
 
 /**
+ * Read backup settings from AdminSettings DB row
+ */
+async function getBackupSettings(): Promise<{
+  enabled: boolean;
+  interval: 'daily' | 'weekly' | 'monthly';
+  retentionDays: number;
+}> {
+  const adminSettings = await prisma.adminSettings.findFirst();
+  return {
+    enabled: adminSettings?.backupEnabled ?? false,
+    interval: (adminSettings?.backupInterval as 'daily' | 'weekly' | 'monthly') ?? 'weekly',
+    retentionDays: adminSettings?.backupRetentionDays ?? 30,
+  };
+}
+
+/**
  * Get cron pattern for backup interval
  */
 function getCronPattern(interval: 'daily' | 'weekly' | 'monthly'): string {
@@ -26,11 +42,7 @@ function getCronPattern(interval: 'daily' | 'weekly' | 'monthly'): string {
  */
 async function checkAndRunBackup(): Promise<void> {
   try {
-    // Get admin settings to check backup configuration
-    // Note: Backup settings are stored in UserSettings for the admin user
-    // For now, we'll check system-wide settings or use environment variables
-    const autoBackup = process.env.AUTO_BACKUP_ENABLED === 'true';
-    const backupInterval = (process.env.BACKUP_INTERVAL as 'daily' | 'weekly' | 'monthly') || 'weekly';
+    const { enabled: autoBackup, interval: backupInterval } = await getBackupSettings();
 
     if (!autoBackup) {
       logger.debug({
@@ -89,9 +101,7 @@ export async function startScheduler(): Promise<void> {
     return;
   }
 
-  // Get settings from environment or default
-  const autoBackup = process.env.AUTO_BACKUP_ENABLED === 'true';
-  const backupInterval = (process.env.BACKUP_INTERVAL as 'daily' | 'weekly' | 'monthly') || 'weekly';
+  const { enabled: autoBackup, interval: backupInterval } = await getBackupSettings();
 
   if (!autoBackup) {
     logger.info({
@@ -147,13 +157,16 @@ export async function updateSchedule(): Promise<void> {
 /**
  * Get current schedule status
  */
-export function getScheduleStatus(): { running: boolean; cronPattern?: string; interval?: string } {
+export async function getScheduleStatus(): Promise<{
+  running: boolean;
+  cronPattern?: string;
+  interval?: string;
+}> {
   if (!scheduledJob) {
     return { running: false };
   }
 
-  const autoBackup = process.env.AUTO_BACKUP_ENABLED === 'true';
-  const backupInterval = (process.env.BACKUP_INTERVAL as 'daily' | 'weekly' | 'monthly') || 'weekly';
+  const { enabled: autoBackup, interval: backupInterval } = await getBackupSettings();
 
   if (!autoBackup) {
     return { running: false };
@@ -165,17 +178,3 @@ export function getScheduleStatus(): { running: boolean; cronPattern?: string; i
     interval: backupInterval,
   };
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/backend/src/services/backupService.ts
+++ b/backend/src/services/backupService.ts
@@ -1054,8 +1054,10 @@ export async function restoreBackup(id: string, options: RestoreOptions): Promis
  * Cleanup old backups based on retention policy
  */
 export async function cleanupOldBackups(): Promise<number> {
+  const adminSettings = await prisma.adminSettings.findFirst();
+  const retentionDays = adminSettings?.backupRetentionDays ?? RETENTION_DAYS;
   const cutoffDate = new Date();
-  cutoffDate.setDate(cutoffDate.getDate() - RETENTION_DAYS);
+  cutoffDate.setDate(cutoffDate.getDate() - retentionDays);
 
   const oldBackups = await prisma.backup.findMany({
     where: {

--- a/backend/src/services/loggingConfig.ts
+++ b/backend/src/services/loggingConfig.ts
@@ -10,7 +10,6 @@ import { CACHE_TTL, LOGGING_DEFAULTS } from '../config/constants';
  */
 
 export interface LogConfig {
-  debugLoggingEnabled: boolean;
   logLevel: string;
   maxLogFileSize: number;
   maxLogFiles: number;
@@ -41,7 +40,6 @@ export async function getLoggingConfig(): Promise<LogConfig> {
     const settings = await prisma.adminSettings.findFirst();
 
     const config: LogConfig = {
-      debugLoggingEnabled: settings?.debugLoggingEnabled ?? false,
       logLevel: settings?.logLevel ?? 'info',
       maxLogFileSize: settings?.maxLogFileSize ?? LOGGING_DEFAULTS.MAX_LOG_FILE_SIZE_MB,
       maxLogFiles: settings?.maxLogFiles ?? LOGGING_DEFAULTS.MAX_LOG_FILES,
@@ -67,7 +65,6 @@ export async function getLoggingConfig(): Promise<LogConfig> {
 
     // Return defaults on error
     return {
-      debugLoggingEnabled: false,
       logLevel: 'info',
       maxLogFileSize: LOGGING_DEFAULTS.MAX_LOG_FILE_SIZE_MB,
       maxLogFiles: LOGGING_DEFAULTS.MAX_LOG_FILES,
@@ -129,9 +126,10 @@ export async function updateLoggingConfig(updates: Partial<LogConfig>): Promise<
 
 /**
  * Toggle debug logging on/off (convenience method)
+ * Sets logLevel to 'debug' when enabled, 'info' when disabled
  */
 export async function toggleDebugLogging(enabled: boolean): Promise<void> {
-  await updateLoggingConfig({ debugLoggingEnabled: enabled });
+  await updateLoggingConfig({ logLevel: enabled ? 'debug' : 'info' });
 
   systemLogger.info({
     operation: 'debug_logging_toggled',
@@ -147,7 +145,7 @@ export async function toggleDebugLogging(enabled: boolean): Promise<void> {
  */
 export async function isDebugEnabled(): Promise<boolean> {
   const config = await getLoggingConfig();
-  return config.debugLoggingEnabled;
+  return config.logLevel === 'debug' || config.logLevel === 'trace';
 }
 
 /**
@@ -155,7 +153,8 @@ export async function isDebugEnabled(): Promise<boolean> {
  */
 export async function shouldLogHttpRequests(): Promise<boolean> {
   const config = await getLoggingConfig();
-  return config.logHttpRequests && config.debugLoggingEnabled;
+  const isDebugLevel = config.logLevel === 'debug' || config.logLevel === 'trace';
+  return config.logHttpRequests && isDebugLevel;
 }
 
 /**
@@ -163,7 +162,8 @@ export async function shouldLogHttpRequests(): Promise<boolean> {
  */
 export async function shouldLogDatabaseQueries(): Promise<boolean> {
   const config = await getLoggingConfig();
-  return config.logDatabaseQueries && config.debugLoggingEnabled;
+  const isDebugLevel = config.logLevel === 'debug' || config.logLevel === 'trace';
+  return config.logDatabaseQueries && isDebugLevel;
 }
 
 /**
@@ -171,7 +171,8 @@ export async function shouldLogDatabaseQueries(): Promise<boolean> {
  */
 export async function shouldLogParserOperations(): Promise<boolean> {
   const config = await getLoggingConfig();
-  return config.logParserOperations && config.debugLoggingEnabled;
+  const isDebugLevel = config.logLevel === 'debug' || config.logLevel === 'trace';
+  return config.logParserOperations && isDebugLevel;
 }
 
 /**
@@ -188,7 +189,7 @@ export function invalidateCache(): void {
  */
 export async function invalidateCacheAndReinit(): Promise<void> {
   invalidateCache();
-  
+
   // Reinitialize logger streams with new config
   const { reinitializeCategoryStreams } = await import('../utils/logger');
   await reinitializeCategoryStreams();

--- a/backend/src/services/parserSettings.ts
+++ b/backend/src/services/parserSettings.ts
@@ -18,9 +18,11 @@ export interface AdminParserSettings {
   globalOpenaiApiKey?: string | null;
   globalClaudeApiKey?: string | null;
   allowUserApiKeys?: boolean;
-  requireUserApiKeys?: boolean;
   defaultVisionParser?: string | null;
   defaultTextParser?: string | null;
+  ollamaUrl?: string | null;
+  ollamaModel?: string | null;
+  ollamaVisionModel?: string | null;
 }
 
 /**
@@ -66,9 +68,11 @@ export async function getAdminParserSettings(): Promise<AdminParserSettings | nu
     globalOpenaiApiKey: decryptApiKey(settings.globalOpenaiApiKey),
     globalClaudeApiKey: decryptApiKey(settings.globalClaudeApiKey),
     allowUserApiKeys: settings.allowUserApiKeys,
-    requireUserApiKeys: settings.requireUserApiKeys,
     defaultVisionParser: settings.defaultVisionParser,
     defaultTextParser: settings.defaultTextParser,
+    ollamaUrl: settings.ollamaUrl,
+    ollamaModel: settings.ollamaModel,
+    ollamaVisionModel: settings.ollamaVisionModel,
   };
 }
 
@@ -92,4 +96,3 @@ export async function getParserConfigWithSettings(userId: string): Promise<Parse
     adminSettings: adminSettings || undefined,
   };
 }
-

--- a/backend/src/services/parsers/config.ts
+++ b/backend/src/services/parsers/config.ts
@@ -108,8 +108,8 @@ export async function getParserConfig(
       getDefaultTextFallbackChain()
     ),
     ollamaUrl: adminSettings?.ollamaUrl || process.env.OLLAMA_URL,
-    ollamaModel: selectedEmailModel,
-    ollamaVisionModel: selectedVisionModel,
+    ollamaModel: adminSettings?.ollamaModel || selectedEmailModel,
+    ollamaVisionModel: adminSettings?.ollamaVisionModel || selectedVisionModel,
     openaiApiKey: userSettings?.openaiApiKey || adminSettings?.globalOpenaiApiKey || process.env.OPENAI_API_KEY,
     openaiModel: process.env.OPENAI_MODEL,
     openaiVisionModel: process.env.OPENAI_VISION_MODEL,

--- a/backend/src/services/parsers/config.ts
+++ b/backend/src/services/parsers/config.ts
@@ -82,6 +82,9 @@ export async function getParserConfig(
   adminSettings?: {
     globalOpenaiApiKey?: string | null;
     globalClaudeApiKey?: string | null;
+    ollamaUrl?: string | null;
+    ollamaModel?: string | null;
+    ollamaVisionModel?: string | null;
   },
   userId?: string
 ): Promise<ParserConfig> {
@@ -104,7 +107,7 @@ export async function getParserConfig(
       userSettings?.textFallbackChain || undefined,
       getDefaultTextFallbackChain()
     ),
-    ollamaUrl: process.env.OLLAMA_URL,
+    ollamaUrl: adminSettings?.ollamaUrl || process.env.OLLAMA_URL,
     ollamaModel: selectedEmailModel,
     ollamaVisionModel: selectedVisionModel,
     openaiApiKey: userSettings?.openaiApiKey || adminSettings?.globalOpenaiApiKey || process.env.OPENAI_API_KEY,

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -40,7 +40,7 @@ function createRotatingStream(category: string, maxSizeMB: number = 10, maxFiles
       } else {
         console.warn(`[Logger] Error writing to log file ${category}.log: ${error.message}`);
       }
-      
+
       // Close the stream gracefully
       try {
         if (typeof (stream as NodeJS.WritableStream & { end?: () => void }).end === 'function') {
@@ -217,7 +217,7 @@ export async function initializeCategoryStreams(): Promise<void> {
   try {
     const config = await getLoggingConfig();
     const fs = require('fs');
-    
+
     // Ensure log directory exists
     try {
       if (!fs.existsSync(LOG_DIR)) {
@@ -248,7 +248,7 @@ export async function initializeCategoryStreams(): Promise<void> {
     }
 
     // Parser logs (if enabled)
-    if (config.logParserOperations && config.debugLoggingEnabled) {
+    if (config.logParserOperations && (config.logLevel === 'debug' || config.logLevel === 'trace')) {
       // Main parser log (all parser operations)
       const parserStream = createRotatingStream('parser', config.maxLogFileSize, config.maxLogFiles);
       if (parserStream) {
@@ -285,7 +285,7 @@ export async function initializeCategoryStreams(): Promise<void> {
     }
 
     // HTTP logs (if enabled)
-    if (config.logHttpRequests && config.debugLoggingEnabled) {
+    if (config.logHttpRequests && (config.logLevel === 'debug' || config.logLevel === 'trace')) {
       const httpStream = createRotatingStream('http', config.maxLogFileSize, config.maxLogFiles);
       if (httpStream) {
         categoryStreams.set('http', {
@@ -296,7 +296,7 @@ export async function initializeCategoryStreams(): Promise<void> {
     }
 
     // Database logs (if enabled)
-    if (config.logDatabaseQueries && config.debugLoggingEnabled) {
+    if (config.logDatabaseQueries && (config.logLevel === 'debug' || config.logLevel === 'trace')) {
       const databaseStream = createRotatingStream('database', config.maxLogFileSize, config.maxLogFiles);
       if (databaseStream) {
         categoryStreams.set('database', {
@@ -324,10 +324,10 @@ export async function reinitializeCategoryStreams(): Promise<void> {
       (streamEntry.stream as NodeJS.WritableStream & { end: () => void }).end();
     }
   }
-  
+
   // Reset logger cache
   resetCategoryLoggerCache();
-  
+
   // Initialize new streams
   await initializeCategoryStreams();
 }
@@ -409,11 +409,11 @@ function resetCategoryLoggerCache(): void {
  * Category-specific loggers
  * These provide structured logging with automatic category tagging
  * and dedicated file streams when enabled in config
- * 
+ *
  * Loggers are created lazily on first use and cached.
  * After reinitializeCategoryStreams(), the cache is cleared and new loggers
  * will be created with updated streams on next use.
- * 
+ *
  * These loggers use the base logger but will also write to category-specific
  * files when streams are initialized via initializeCategoryStreams().
  */

--- a/frontend/src/components/Admin/BackupManagement.tsx
+++ b/frontend/src/components/Admin/BackupManagement.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { backupApi } from "../../lib/api";
+import type { BackupScheduleSettings } from "../../lib/api/backup";
 import { useToastStore } from "../../store/toastStore";
 import { format } from "date-fns";
 import { logger } from "../../lib/logger";
@@ -167,7 +168,7 @@ function RestoreModal({ backup, onClose, onConfirm }: RestoreModalProps): JSX.El
 }
 
 export default function BackupManagement(): JSX.Element {
-  const { t } = useTranslation(["admin", "common"]);
+  const { t } = useTranslation(["admin", "common", "settings"]);
   const addToast = useToastStore((state) => state.addToast);
   const [backups, setBackups] = useState<Backup[]>([]);
   const [loading, setLoading] = useState(true);
@@ -177,6 +178,12 @@ export default function BackupManagement(): JSX.Element {
     running: boolean;
     currentBackup: { id: string; status: string; startedAt: string | null } | null;
   } | null>(null);
+  const [backupSettings, setBackupSettings] = useState<BackupScheduleSettings>({
+    backupEnabled: false,
+    backupInterval: "weekly",
+    backupRetentionDays: 30,
+  });
+  const [savingSettings, setSavingSettings] = useState(false);
 
   const loadBackups = async () => {
     try {
@@ -210,6 +217,13 @@ export default function BackupManagement(): JSX.Element {
     return () => clearInterval(interval);
   }, []);
 
+  useEffect(() => {
+    backupApi
+      .getBackupSettings()
+      .then(setBackupSettings)
+      .catch((err: unknown) => logger.error("Failed to load backup settings", err));
+  }, []);
+
   const handleCreateBackup = async () => {
     try {
       setCreating(true);
@@ -224,6 +238,20 @@ export default function BackupManagement(): JSX.Element {
       addToast("error", t("admin:backup.toasts.createFailed"));
     } finally {
       setCreating(false);
+    }
+  };
+
+  const handleSaveBackupSettings = async (): Promise<void> => {
+    setSavingSettings(true);
+    try {
+      const updated = await backupApi.updateBackupSettings(backupSettings);
+      setBackupSettings(updated);
+      addToast("success", t("admin:backup.settingsSaved"));
+    } catch (err: unknown) {
+      addToast("error", t("admin:backup.settingsFailed"));
+      logger.error("Failed to save backup settings", err);
+    } finally {
+      setSavingSettings(false);
     }
   };
 
@@ -397,6 +425,82 @@ export default function BackupManagement(): JSX.Element {
           </div>
         }
       />
+
+      {/* Backup Schedule Settings */}
+      <div className="bg-[var(--bg-surface)] rounded-lg shadow p-6 mb-6">
+        <div className="flex items-center justify-between mb-4">
+          <div>
+            <h3 className="text-lg font-semibold text-[var(--text-primary)]">
+              {t("admin:backup.schedule.title")}
+            </h3>
+            <p className="text-sm text-[var(--text-muted)] mt-1">
+              {t("admin:backup.schedule.description")}
+            </p>
+          </div>
+          <button
+            onClick={handleSaveBackupSettings}
+            disabled={savingSettings}
+            className="bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-lg transition font-medium text-sm"
+          >
+            {savingSettings ? t("common:buttons.saving") : t("common:buttons.save")}
+          </button>
+        </div>
+        <div className="space-y-4">
+          <label className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              checked={backupSettings.backupEnabled}
+              onChange={(e) =>
+                setBackupSettings({ ...backupSettings, backupEnabled: e.target.checked })
+              }
+              className="w-4 h-4 rounded"
+            />
+            <span className="text-sm font-medium text-[var(--text-primary)]">
+              {t("admin:backup.schedule.enableAutoBackup")}
+            </span>
+          </label>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">
+                {t("admin:backup.schedule.interval")}
+              </label>
+              <select
+                value={backupSettings.backupInterval}
+                onChange={(e) =>
+                  setBackupSettings({
+                    ...backupSettings,
+                    backupInterval: e.target.value as BackupScheduleSettings["backupInterval"],
+                  })
+                }
+                disabled={!backupSettings.backupEnabled}
+                className="input w-full disabled:opacity-50"
+              >
+                <option value="daily">{t("settings:backup.intervals.daily")}</option>
+                <option value="weekly">{t("settings:backup.intervals.weekly")}</option>
+                <option value="monthly">{t("settings:backup.intervals.monthly")}</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">
+                {t("admin:backup.schedule.retentionDays")}
+              </label>
+              <input
+                type="number"
+                value={backupSettings.backupRetentionDays}
+                onChange={(e) =>
+                  setBackupSettings({
+                    ...backupSettings,
+                    backupRetentionDays: parseInt(e.target.value, 10) || 30,
+                  })
+                }
+                min="1"
+                max="365"
+                className="input w-full"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
 
       {status?.running && status.currentBackup && (
         <div

--- a/frontend/src/components/Admin/GlobalApiKeysManager.tsx
+++ b/frontend/src/components/Admin/GlobalApiKeysManager.tsx
@@ -17,7 +17,6 @@ export interface ParserApiKeySettings {
   globalOpenaiApiKey?: string;
   globalClaudeApiKey?: string;
   allowUserApiKeys: boolean;
-  requireUserApiKeys: boolean;
 }
 
 interface GlobalApiKeysManagerProps {
@@ -233,27 +232,6 @@ export default function GlobalApiKeysManager({
                       </span>
                       <p className="text-sm text-[var(--text-muted)]">
                         {t("admin:globalApiKeys.allowUserParserApiKeysDescription")}
-                      </p>
-                    </div>
-                  </label>
-                  <label className="flex items-start gap-3">
-                    <input
-                      type="checkbox"
-                      checked={parserSettings.requireUserApiKeys}
-                      onChange={(e) =>
-                        onParserSettingsChange({
-                          ...parserSettings,
-                          requireUserApiKeys: e.target.checked,
-                        })
-                      }
-                      className="checkbox mt-1"
-                    />
-                    <div>
-                      <span className="font-medium text-[var(--text-primary)]">
-                        {t("admin:globalApiKeys.requireUserParserApiKeys")}
-                      </span>
-                      <p className="text-sm text-[var(--text-muted)]">
-                        {t("admin:globalApiKeys.requireUserParserApiKeysDescription")}
                       </p>
                     </div>
                   </label>

--- a/frontend/src/components/Admin/ParserSettings.tsx
+++ b/frontend/src/components/Admin/ParserSettings.tsx
@@ -5,7 +5,6 @@ export interface ParserSettingsData {
   globalOpenaiApiKey?: string;
   globalClaudeApiKey?: string;
   allowUserApiKeys: boolean;
-  requireUserApiKeys: boolean;
   defaultVisionParser: string;
   defaultTextParser: string;
   ollamaUrl: string | null;

--- a/frontend/src/components/Admin/ParserSettings.tsx
+++ b/frontend/src/components/Admin/ParserSettings.tsx
@@ -8,6 +8,9 @@ export interface ParserSettingsData {
   requireUserApiKeys: boolean;
   defaultVisionParser: string;
   defaultTextParser: string;
+  ollamaUrl: string | null;
+  ollamaModel: string | null;
+  ollamaVisionModel: string | null;
 }
 
 interface ParserSettingsProps {
@@ -121,6 +124,76 @@ export default function ParserSettings({
             <p className="text-xs text-[var(--text-muted)] mt-1">
               {t("admin:parserSettings.autoHelp")}
             </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Ollama Configuration */}
+      <div className="bg-[var(--bg-surface)] rounded-lg shadow p-6">
+        <h3 className="text-lg font-semibold text-[var(--text-primary)] mb-1">
+          Ollama Configuration
+        </h3>
+        <p className="text-sm text-[var(--text-muted)] mb-4">
+          Configure the local Ollama instance used for AI parsing. Leave blank to use the{" "}
+          <code className="text-xs bg-[var(--bg-elevated)] px-1 rounded">OLLAMA_URL</code>{" "}
+          environment variable.
+        </p>
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">
+              Ollama URL
+            </label>
+            <input
+              type="url"
+              value={parserSettings.ollamaUrl ?? ""}
+              onChange={(e) =>
+                onParserSettingsChange({
+                  ...parserSettings,
+                  ollamaUrl: e.target.value || null,
+                })
+              }
+              placeholder="http://192.168.178.155:11434"
+              className="input w-full"
+            />
+            <p className="text-xs text-[var(--text-muted)] mt-1">
+              Full URL including port. DB value overrides OLLAMA_URL env var.
+            </p>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">
+                Text Model
+              </label>
+              <input
+                type="text"
+                value={parserSettings.ollamaModel ?? ""}
+                onChange={(e) =>
+                  onParserSettingsChange({
+                    ...parserSettings,
+                    ollamaModel: e.target.value || null,
+                  })
+                }
+                placeholder="qwen2.5:7b"
+                className="input w-full"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-[var(--text-primary)] mb-1">
+                Vision Model
+              </label>
+              <input
+                type="text"
+                value={parserSettings.ollamaVisionModel ?? ""}
+                onChange={(e) =>
+                  onParserSettingsChange({
+                    ...parserSettings,
+                    ollamaVisionModel: e.target.value || null,
+                  })
+                }
+                placeholder="llama3.2-vision"
+                className="input w-full"
+              />
+            </div>
           </div>
         </div>
       </div>

--- a/frontend/src/components/Settings/BackupSection.tsx
+++ b/frontend/src/components/Settings/BackupSection.tsx
@@ -1,6 +1,5 @@
-import { AmberToggle, SectionCard, SectionTitle } from "./SettingsShared";
 import { useTranslation } from "../../hooks/useTranslation";
-import type { BackupSettings } from "../../store/settingsStore";
+import { SectionCard, SectionTitle } from "./SettingsShared";
 
 interface LastBackup {
   completedAt: string | null;
@@ -9,23 +8,15 @@ interface LastBackup {
 }
 
 interface BackupSectionProps {
-  backup: BackupSettings;
-  retentionDays: number;
   lastBackup: LastBackup | null;
   backupStatus: { running: boolean } | null;
   isAdmin: boolean;
-  onSetBackup: (partial: Partial<BackupSettings>) => void;
-  onSetRetentionDays: (days: number) => void;
 }
 
 export default function BackupSection({
-  backup,
-  retentionDays,
   lastBackup,
   backupStatus,
   isAdmin,
-  onSetBackup,
-  onSetRetentionDays,
 }: BackupSectionProps): JSX.Element {
   const { t } = useTranslation(["settings"]);
 
@@ -36,102 +27,39 @@ export default function BackupSection({
         description={t("settings:backup.description")}
       />
       <div className="space-y-3">
-        <label className="flex items-center gap-3">
-          <AmberToggle
-            checked={backup.autoBackup}
-            onChange={(e) => onSetBackup({ autoBackup: e.target.checked })}
-          />
-          <span style={{ color: "var(--text-primary)" }}>{t("settings:backup.autoBackup")}</span>
-        </label>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label className="label">{t("settings:backup.backupInterval")}</label>
-            <select
-              value={backup.backupInterval}
-              onChange={(e) =>
-                onSetBackup({ backupInterval: e.target.value as typeof backup.backupInterval })
-              }
-              className="input"
-            >
-              <option value="daily">{t("settings:backup.intervals.daily")}</option>
-              <option value="weekly">{t("settings:backup.intervals.weekly")}</option>
-              <option value="monthly">{t("settings:backup.intervals.monthly")}</option>
-            </select>
-          </div>
-          <div>
-            <label className="label">{t("settings:backup.exportFormat")}</label>
-            <select
-              value={backup.exportFormat}
-              onChange={(e) =>
-                onSetBackup({ exportFormat: e.target.value as typeof backup.exportFormat })
-              }
-              className="input"
-            >
-              <option value="json">{t("settings:backup.formats.json")}</option>
-              <option value="csv">{t("settings:backup.formats.csv")}</option>
-              <option value="pdf">{t("settings:backup.formats.pdf")}</option>
-            </select>
-          </div>
-        </div>
-        <label className="flex items-center gap-3">
-          <AmberToggle
-            checked={backup.cloudSync}
-            onChange={(e) => onSetBackup({ cloudSync: e.target.checked })}
-          />
-          <span style={{ color: "var(--text-primary)" }}>{t("settings:backup.cloudSync")}</span>
-        </label>
-        <div>
-          <label className="label">{t("settings:backup.retentionDays")}</label>
-          <input
-            type="number"
-            value={retentionDays}
-            onChange={(e) => onSetRetentionDays(parseInt(e.target.value, 10) || 30)}
-            min="1"
-            max="365"
-            className="input"
-          />
-          <p className="text-xs mt-1" style={{ color: "var(--text-muted)" }}>
-            {t("settings:backup.retentionDaysDescription", { days: retentionDays })}
+        {isAdmin ? (
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            {t("settings:backup.adminNote")}
           </p>
-        </div>
-        {isAdmin && (
-          <>
-            <div className="pt-2" style={{ borderTop: "1px solid var(--color-border)" }}>
-              <p className="text-sm font-medium mb-2" style={{ color: "var(--text-primary)" }}>
-                {t("settings:backup.status.title")}
-              </p>
-              {backupStatus?.running ? (
-                <div className="flex items-center gap-2" style={{ color: "var(--accent)" }}>
-                  <span className="animate-pulse">&#9679;</span>
-                  <span>{t("settings:backup.status.running")}</span>
-                </div>
-              ) : lastBackup ? (
-                <div className="space-y-1">
-                  <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-                    {t("settings:backup.status.lastBackup", {
-                      date: lastBackup.completedAt
-                        ? new Date(lastBackup.completedAt).toLocaleString("de-DE")
-                        : "-",
-                    })}
-                  </p>
-                  <p className="text-xs" style={{ color: "var(--text-muted)" }}>
-                    {t("settings:backup.status.size", {
-                      size: (parseInt(lastBackup.size, 10) / 1024 / 1024).toFixed(2),
-                    })}
-                  </p>
-                </div>
-              ) : (
-                <p className="text-sm" style={{ color: "var(--text-muted)" }}>
-                  {t("settings:backup.status.noBackup")}
-                </p>
-              )}
-            </div>
-            <div className="pt-2">
-              <p className="text-xs" style={{ color: "var(--text-muted)" }}>
-                {t("settings:backup.status.path", { path: "/app/data/backups" })}
-              </p>
-            </div>
-          </>
+        ) : (
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            {t("settings:backup.userNote")}
+          </p>
+        )}
+        {backupStatus?.running ? (
+          <div className="flex items-center gap-2" style={{ color: "var(--accent)" }}>
+            <span className="animate-pulse">&#9679;</span>
+            <span>{t("settings:backup.status.running")}</span>
+          </div>
+        ) : lastBackup ? (
+          <div className="space-y-1">
+            <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+              {t("settings:backup.status.lastBackup", {
+                date: lastBackup.completedAt
+                  ? new Date(lastBackup.completedAt).toLocaleString("de-DE")
+                  : "-",
+              })}
+            </p>
+            <p className="text-xs" style={{ color: "var(--text-muted)" }}>
+              {t("settings:backup.status.size", {
+                size: (parseInt(lastBackup.size, 10) / 1024 / 1024).toFixed(2),
+              })}
+            </p>
+          </div>
+        ) : (
+          <p className="text-sm" style={{ color: "var(--text-muted)" }}>
+            {t("settings:backup.status.noBackup")}
+          </p>
         )}
       </div>
     </SectionCard>

--- a/frontend/src/components/Settings/NotificationsSection.tsx
+++ b/frontend/src/components/Settings/NotificationsSection.tsx
@@ -1,17 +1,8 @@
-import { AmberToggle, SectionCard, SectionTitle } from "./SettingsShared";
+import { SectionCard, SectionTitle } from "./SettingsShared";
 import NotificationPreferences from "./NotificationPreferences";
 import { useTranslation } from "../../hooks/useTranslation";
-import type { NotificationSettings } from "../../store/settingsStore";
 
-interface NotificationsSectionProps {
-  notifications: NotificationSettings;
-  onSetNotifications: (partial: Partial<NotificationSettings>) => void;
-}
-
-export default function NotificationsSection({
-  notifications,
-  onSetNotifications,
-}: NotificationsSectionProps): JSX.Element {
+export default function NotificationsSection(): JSX.Element {
   const { t } = useTranslation(["settings"]);
 
   return (
@@ -20,52 +11,6 @@ export default function NotificationsSection({
         title={t("settings:notifications.title")}
         description={t("settings:notifications.description")}
       />
-      <div className="space-y-3">
-        <label className="flex items-center gap-3">
-          <AmberToggle
-            checked={notifications.emailNotifications}
-            onChange={(e) => onSetNotifications({ emailNotifications: e.target.checked })}
-          />
-          <span style={{ color: "var(--text-primary)" }}>
-            {t("settings:notifications.emailNotifications")}
-          </span>
-        </label>
-        <label className="flex items-center gap-3">
-          <AmberToggle
-            checked={notifications.checkInReminder}
-            onChange={(e) => onSetNotifications({ checkInReminder: e.target.checked })}
-          />
-          <span style={{ color: "var(--text-primary)" }}>
-            {t("settings:notifications.checkInReminder")}
-          </span>
-        </label>
-        <div>
-          <label className="label">{t("settings:notifications.flightReminder")}</label>
-          <select
-            value={notifications.flightReminder}
-            onChange={(e) =>
-              onSetNotifications({
-                flightReminder: e.target.value as typeof notifications.flightReminder,
-              })
-            }
-            className="input"
-          >
-            <option value="off">{t("settings:notifications.options.off")}</option>
-            <option value="24h">{t("settings:notifications.options.24h")}</option>
-            <option value="48h">{t("settings:notifications.options.48h")}</option>
-          </select>
-        </div>
-        <label className="flex items-center gap-3">
-          <AmberToggle
-            checked={notifications.featureUpdates}
-            onChange={(e) => onSetNotifications({ featureUpdates: e.target.checked })}
-          />
-          <span style={{ color: "var(--text-primary)" }}>
-            {t("settings:notifications.featureUpdates")}
-          </span>
-        </label>
-      </div>
-      <hr style={{ borderColor: "var(--border-color)", margin: "1.5rem 0" }} />
       <NotificationPreferences />
     </SectionCard>
   );

--- a/frontend/src/components/Settings/useSettingsPage.ts
+++ b/frontend/src/components/Settings/useSettingsPage.ts
@@ -43,17 +43,13 @@ export function useSettingsPage() {
     units,
     defaults,
     map,
-    notifications,
     privacy,
-    backup,
     setProfile,
     setDisplay,
     setUnits,
     setDefaults,
     setMap,
-    setNotifications,
     setPrivacy,
-    setBackup,
     boardingPassParserStrategy,
     setBoardingPassParserStrategy,
     saveRemoteSettings,
@@ -88,7 +84,6 @@ export function useSettingsPage() {
     status: string;
   } | null>(null);
   const [backupStatus, setBackupStatus] = useState<{ running: boolean } | null>(null);
-  const [retentionDays, setRetentionDays] = useState(30);
 
   // Auto-update
   const [autoUpdateSettings, setAutoUpdateSettings] = useState<AutoUpdateSettings>({
@@ -414,17 +409,13 @@ export function useSettingsPage() {
     units,
     defaults,
     map,
-    notifications,
     privacy,
-    backup,
     setProfile,
     setDisplay,
     setUnits,
     setDefaults,
     setMap,
-    setNotifications,
     setPrivacy,
-    setBackup,
     boardingPassParserStrategy,
     setBoardingPassParserStrategy,
     isDarkMode,
@@ -455,8 +446,6 @@ export function useSettingsPage() {
     // Backup
     lastBackup,
     backupStatus,
-    retentionDays,
-    setRetentionDays,
     // Auto-update
     autoUpdateSettings,
     setAutoUpdateSettings,

--- a/frontend/src/i18n/resources/de/admin.json
+++ b/frontend/src/i18n/resources/de/admin.json
@@ -381,6 +381,15 @@
       "confirmText": "Wiederherstellen",
       "confirmButton": "Wiederherstellen"
     },
+    "settingsSaved": "Backup-Einstellungen gespeichert",
+    "settingsFailed": "Fehler beim Speichern der Einstellungen",
+    "schedule": {
+      "title": "Automatisches Backup",
+      "description": "Geplante Backups werden täglich um 2:00 Uhr ausgeführt.",
+      "enableAutoBackup": "Automatisches Backup aktivieren",
+      "interval": "Intervall",
+      "retentionDays": "Aufbewahrung (Tage)"
+    },
     "toasts": {
       "loadFailed": "Fehler beim Laden der Backups",
       "started": "Backup gestartet",

--- a/frontend/src/i18n/resources/de/settings.json
+++ b/frontend/src/i18n/resources/de/settings.json
@@ -139,6 +139,8 @@
   "backup": {
     "title": "Backup & Sync",
     "description": "Regelmäßige Sicherungen und Cloud-Sync steuern.",
+    "adminNote": "Backup-Einstellungen werden im Admin-Panel verwaltet.",
+    "userNote": "Backups werden vom Administrator verwaltet.",
     "autoBackup": "Automatische Backups aktivieren",
     "backupInterval": "Backup-Intervall",
     "exportFormat": "Export-Format",

--- a/frontend/src/i18n/resources/en/admin.json
+++ b/frontend/src/i18n/resources/en/admin.json
@@ -381,6 +381,15 @@
       "confirmText": "Restore",
       "confirmButton": "Restore"
     },
+    "settingsSaved": "Backup settings saved",
+    "settingsFailed": "Failed to save backup settings",
+    "schedule": {
+      "title": "Automatic Backup",
+      "description": "Scheduled backups run at 2:00 AM.",
+      "enableAutoBackup": "Enable automatic backup",
+      "interval": "Interval",
+      "retentionDays": "Retention (days)"
+    },
     "toasts": {
       "loadFailed": "Failed to load backups",
       "started": "Backup started",

--- a/frontend/src/i18n/resources/en/settings.json
+++ b/frontend/src/i18n/resources/en/settings.json
@@ -139,6 +139,8 @@
   "backup": {
     "title": "Backup & Sync",
     "description": "Control regular backups and cloud sync.",
+    "adminNote": "Backup settings are managed in the Admin panel.",
+    "userNote": "Backups are managed by the administrator.",
     "autoBackup": "Enable automatic backups",
     "backupInterval": "Backup Interval",
     "exportFormat": "Export Format",

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -245,7 +245,6 @@ export const adminApi = {
     globalOpenaiApiKey?: string;
     globalClaudeApiKey?: string;
     allowUserApiKeys: boolean;
-    requireUserApiKeys: boolean;
     defaultVisionParser: string;
     defaultTextParser: string;
     ollamaUrl: string | null;
@@ -256,7 +255,6 @@ export const adminApi = {
       globalOpenaiApiKey?: string;
       globalClaudeApiKey?: string;
       allowUserApiKeys: boolean;
-      requireUserApiKeys: boolean;
       defaultVisionParser: string;
       defaultTextParser: string;
       ollamaUrl: string | null;
@@ -270,7 +268,6 @@ export const adminApi = {
     globalOpenaiApiKey?: string;
     globalClaudeApiKey?: string;
     allowUserApiKeys?: boolean;
-    requireUserApiKeys?: boolean;
     defaultVisionParser?: string;
     defaultTextParser?: string;
     ollamaUrl?: string | null;

--- a/frontend/src/lib/api/admin.ts
+++ b/frontend/src/lib/api/admin.ts
@@ -248,6 +248,9 @@ export const adminApi = {
     requireUserApiKeys: boolean;
     defaultVisionParser: string;
     defaultTextParser: string;
+    ollamaUrl: string | null;
+    ollamaModel: string | null;
+    ollamaVisionModel: string | null;
   }> => {
     const { data } = await api.get<{
       globalOpenaiApiKey?: string;
@@ -256,6 +259,9 @@ export const adminApi = {
       requireUserApiKeys: boolean;
       defaultVisionParser: string;
       defaultTextParser: string;
+      ollamaUrl: string | null;
+      ollamaModel: string | null;
+      ollamaVisionModel: string | null;
     }>("/admin/parser-settings");
     return data;
   },
@@ -267,6 +273,9 @@ export const adminApi = {
     requireUserApiKeys?: boolean;
     defaultVisionParser?: string;
     defaultTextParser?: string;
+    ollamaUrl?: string | null;
+    ollamaModel?: string | null;
+    ollamaVisionModel?: string | null;
   }): Promise<MessageResponse> => {
     const { data } = await api.put<MessageResponse>("/admin/parser-settings", settings);
     return data;

--- a/frontend/src/lib/api/backup.ts
+++ b/frontend/src/lib/api/backup.ts
@@ -1,7 +1,25 @@
 import { api } from "./client";
 import type { BackupEntry } from "./types";
 
+export interface BackupScheduleSettings {
+  backupEnabled: boolean;
+  backupInterval: "daily" | "weekly" | "monthly";
+  backupRetentionDays: number;
+}
+
 export const backupApi = {
+  getBackupSettings: async (): Promise<BackupScheduleSettings> => {
+    const { data } = await api.get<BackupScheduleSettings>("/admin/backup-settings");
+    return data;
+  },
+
+  updateBackupSettings: async (
+    settings: Partial<BackupScheduleSettings>
+  ): Promise<BackupScheduleSettings> => {
+    const { data } = await api.put<BackupScheduleSettings>("/admin/backup-settings", settings);
+    return data;
+  },
+
   list: async (): Promise<{
     backups: BackupEntry[];
   }> => {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -139,10 +139,7 @@ export interface UserSettings {
     routeColor?: string;
   };
   notifications?: {
-    emailNotifications?: boolean;
     flightReminder?: string;
-    checkInReminder?: boolean;
-    featureUpdates?: boolean;
   };
   privacy?: {
     twoFactorAuth?: boolean;
@@ -151,12 +148,7 @@ export interface UserSettings {
     accountDeletionRequested?: boolean;
     analyticsOptIn?: boolean;
   };
-  backup?: {
-    autoBackup?: boolean;
-    backupInterval?: string;
-    exportFormat?: string;
-    cloudSync?: boolean;
-  };
+  backup?: Record<string, never>;
   autoUpdate?: AutoUpdateSettings;
   historicalEnrichment?: HistoricalEnrichmentSettings;
   boardingPassParserStrategy?: "parser-only" | "parser-with-api" | "api-only" | null;

--- a/frontend/src/lib/dateUtils.test.ts
+++ b/frontend/src/lib/dateUtils.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { formatDateInTimezone, formatDateTimeInTimezone } from "./dateUtils";
+
+describe("dateUtils", () => {
+  const date = new Date("2026-05-01T10:00:00Z"); // 10:00 UTC
+
+  it("formats date in UTC timezone", () => {
+    const result = formatDateInTimezone(date, "UTC");
+    expect(result).toBe("01.05.2026");
+  });
+
+  it("formats date in Berlin timezone (UTC+2 in summer)", () => {
+    const result = formatDateInTimezone(date, "Europe/Berlin");
+    expect(result).toBe("01.05.2026");
+  });
+
+  it("formats datetime with time component", () => {
+    const result = formatDateTimeInTimezone(date, "UTC");
+    expect(result).toContain("10:00");
+  });
+
+  it("handles string date input", () => {
+    const result = formatDateInTimezone("2026-05-01T10:00:00Z", "UTC");
+    expect(result).toBe("01.05.2026");
+  });
+
+  it("returns fallback for invalid date", () => {
+    const result = formatDateInTimezone("not-a-date", "UTC");
+    expect(result).toBe("—");
+  });
+});

--- a/frontend/src/lib/dateUtils.test.ts
+++ b/frontend/src/lib/dateUtils.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { formatDateInTimezone, formatDateTimeInTimezone } from "./dateUtils";
+import { formatDateInTimezone, formatDateTimeInTimezone, formatTimeInTimezone } from "./dateUtils";
 
 describe("dateUtils", () => {
   const date = new Date("2026-05-01T10:00:00Z"); // 10:00 UTC
@@ -27,5 +27,16 @@ describe("dateUtils", () => {
   it("returns fallback for invalid date", () => {
     const result = formatDateInTimezone("not-a-date", "UTC");
     expect(result).toBe("—");
+  });
+
+  it("falls back to UTC for invalid timezone", () => {
+    const result = formatDateInTimezone(date, "Invalid/Timezone");
+    // Should not throw — returns a valid date string
+    expect(result).toMatch(/\d{2}\.\d{2}\.\d{4}/);
+  });
+
+  it("formats time-only with formatTimeInTimezone", () => {
+    const result = formatTimeInTimezone(date, "UTC");
+    expect(result).toContain("10:00");
   });
 });

--- a/frontend/src/lib/dateUtils.ts
+++ b/frontend/src/lib/dateUtils.ts
@@ -6,18 +6,25 @@ function toDate(input: Date | string): Date | null {
   return isNaN(d.getTime()) ? null : d;
 }
 
+function formatWith(
+  date: Date,
+  options: Omit<Intl.DateTimeFormatOptions, "timeZone">,
+  timezone: string
+): string {
+  try {
+    return new Intl.DateTimeFormat("de-DE", { ...options, timeZone: timezone }).format(date);
+  } catch {
+    return new Intl.DateTimeFormat("de-DE", { ...options, timeZone: "UTC" }).format(date);
+  }
+}
+
 /**
  * Format a date as "dd.MM.yyyy" in the given timezone.
  */
 export function formatDateInTimezone(input: Date | string, timezone: string): string {
   const date = toDate(input);
   if (!date) return FALLBACK;
-  return new Intl.DateTimeFormat("de-DE", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    timeZone: timezone,
-  }).format(date);
+  return formatWith(date, { year: "numeric", month: "2-digit", day: "2-digit" }, timezone);
 }
 
 /**
@@ -26,14 +33,11 @@ export function formatDateInTimezone(input: Date | string, timezone: string): st
 export function formatDateTimeInTimezone(input: Date | string, timezone: string): string {
   const date = toDate(input);
   if (!date) return FALLBACK;
-  return new Intl.DateTimeFormat("de-DE", {
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: timezone,
-  }).format(date);
+  return formatWith(
+    date,
+    { year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit" },
+    timezone
+  );
 }
 
 /**
@@ -42,9 +46,5 @@ export function formatDateTimeInTimezone(input: Date | string, timezone: string)
 export function formatTimeInTimezone(input: Date | string, timezone: string): string {
   const date = toDate(input);
   if (!date) return FALLBACK;
-  return new Intl.DateTimeFormat("de-DE", {
-    hour: "2-digit",
-    minute: "2-digit",
-    timeZone: timezone,
-  }).format(date);
+  return formatWith(date, { hour: "2-digit", minute: "2-digit" }, timezone);
 }

--- a/frontend/src/lib/dateUtils.ts
+++ b/frontend/src/lib/dateUtils.ts
@@ -1,0 +1,50 @@
+const FALLBACK = "—";
+
+function toDate(input: Date | string): Date | null {
+  if (input instanceof Date) return isNaN(input.getTime()) ? null : input;
+  const d = new Date(input);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+/**
+ * Format a date as "dd.MM.yyyy" in the given timezone.
+ */
+export function formatDateInTimezone(input: Date | string, timezone: string): string {
+  const date = toDate(input);
+  if (!date) return FALLBACK;
+  return new Intl.DateTimeFormat("de-DE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    timeZone: timezone,
+  }).format(date);
+}
+
+/**
+ * Format a date+time as "dd.MM.yyyy, HH:mm" in the given timezone.
+ */
+export function formatDateTimeInTimezone(input: Date | string, timezone: string): string {
+  const date = toDate(input);
+  if (!date) return FALLBACK;
+  return new Intl.DateTimeFormat("de-DE", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: timezone,
+  }).format(date);
+}
+
+/**
+ * Format a time-only as "HH:mm" in the given timezone.
+ */
+export function formatTimeInTimezone(input: Date | string, timezone: string): string {
+  const date = toDate(input);
+  if (!date) return FALLBACK;
+  return new Intl.DateTimeFormat("de-DE", {
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: timezone,
+  }).format(date);
+}

--- a/frontend/src/pages/AdminPage.tsx
+++ b/frontend/src/pages/AdminPage.tsx
@@ -257,7 +257,6 @@ export default function AdminPage(): JSX.Element {
           globalOpenaiApiKey: parserSettings?.globalOpenaiApiKey,
           globalClaudeApiKey: parserSettings?.globalClaudeApiKey,
           allowUserApiKeys: parserSettings?.allowUserApiKeys,
-          requireUserApiKeys: parserSettings?.requireUserApiKeys,
         }),
       ]);
       addToast("success", t("admin:globalApiKeys.saved") || "API keys saved successfully");
@@ -540,7 +539,6 @@ export default function AdminPage(): JSX.Element {
                       globalOpenaiApiKey: parserSettings.globalOpenaiApiKey,
                       globalClaudeApiKey: parserSettings.globalClaudeApiKey,
                       allowUserApiKeys: parserSettings.allowUserApiKeys,
-                      requireUserApiKeys: parserSettings.requireUserApiKeys,
                     }
                   : null
               }
@@ -554,7 +552,6 @@ export default function AdminPage(): JSX.Element {
                     globalOpenaiApiKey: apiKeySettings.globalOpenaiApiKey,
                     globalClaudeApiKey: apiKeySettings.globalClaudeApiKey,
                     allowUserApiKeys: apiKeySettings.allowUserApiKeys,
-                    requireUserApiKeys: apiKeySettings.requireUserApiKeys,
                   });
                 }
               }}

--- a/frontend/src/pages/FlightsTablePage.tsx
+++ b/frontend/src/pages/FlightsTablePage.tsx
@@ -14,7 +14,9 @@ import SimplifiedFlightFormV2 from "../components/SimplifiedFlightFormV2";
 import FlightEditModal from "../components/FlightEditModal";
 import ConfirmModal from "../components/Training/ConfirmModal";
 import { useToastStore } from "../store/toastStore";
-import { API_LIMITS, DATE_FORMATS, getDateLocale } from "../lib/constants";
+import { useSettingsStore } from "../store/settingsStore";
+import { API_LIMITS } from "../lib/constants";
+import { formatDateInTimezone } from "../lib/dateUtils";
 import { useTranslation } from "../hooks/useTranslation";
 import DataSourceBadges from "../components/DataSourceBadges";
 import { logger } from "../lib/logger";
@@ -35,6 +37,7 @@ export default function FlightsTablePage(): JSX.Element {
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [showAddFlight, setShowAddFlight] = useState(false);
   const addToast = useToastStore((state) => state.addToast);
+  const timezone = useSettingsStore((s) => s.display.timezone);
 
   useEffect(() => {
     loadFlights();
@@ -151,9 +154,7 @@ export default function FlightsTablePage(): JSX.Element {
     }
   };
 
-  const formatDate = (date: string) => {
-    return new Date(date).toLocaleDateString(getDateLocale(), DATE_FORMATS.DEFAULT);
-  };
+  const formatDate = (date: string): string => formatDateInTimezone(date, timezone);
 
   const formatDurationHours = (departure: string, arrival: string) => {
     const minutes = getDurationMinutes({

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -33,17 +33,13 @@ export default function SettingsPage(): JSX.Element {
     units,
     defaults,
     map,
-    notifications,
     privacy,
-    backup,
     setProfile,
     setDisplay,
     setUnits,
     setDefaults,
     setMap,
-    setNotifications,
     setPrivacy,
-    setBackup,
     boardingPassParserStrategy,
     setBoardingPassParserStrategy,
     isDarkMode,
@@ -68,8 +64,6 @@ export default function SettingsPage(): JSX.Element {
     closePasswordModal,
     lastBackup,
     backupStatus,
-    retentionDays,
-    setRetentionDays,
     autoUpdateSettings,
     setAutoUpdateSettings,
     loadingAutoUpdateSettings,
@@ -168,24 +162,15 @@ export default function SettingsPage(): JSX.Element {
               <DefaultsSection defaults={defaults} onSetDefaults={setDefaults} />
             )}
             {activeSection === "map" && <MapSection map={map} onSetMap={setMap} />}
-            {activeSection === "notifications" && (
-              <NotificationsSection
-                notifications={notifications}
-                onSetNotifications={setNotifications}
-              />
-            )}
+            {activeSection === "notifications" && <NotificationsSection />}
             {activeSection === "privacy" && (
               <PrivacySection privacy={privacy} onSetPrivacy={setPrivacy} />
             )}
             {activeSection === "backup" && (
               <BackupSection
-                backup={backup}
-                retentionDays={retentionDays}
                 lastBackup={lastBackup}
                 backupStatus={backupStatus}
                 isAdmin={user?.isAdmin ?? false}
-                onSetBackup={setBackup}
-                onSetRetentionDays={setRetentionDays}
               />
             )}
             {activeSection === "parser" && (

--- a/frontend/src/store/settingsStore.ts
+++ b/frontend/src/store/settingsStore.ts
@@ -11,8 +11,6 @@ type FlightCategory = "business" | "private" | "vacation";
 type SeatClass = "economy" | "premium_economy" | "business" | "first";
 
 type FlightReminder = "off" | "24h" | "48h";
-type BackupInterval = "daily" | "weekly" | "monthly";
-type ExportFormat = "json" | "csv" | "pdf";
 
 type MapStyle = "osm" | "satellite";
 type MarkerStyle = "pin" | "circle" | "custom";
@@ -59,10 +57,7 @@ export interface MapSettings {
 }
 
 export interface NotificationSettings {
-  emailNotifications: boolean;
   flightReminder: FlightReminder;
-  checkInReminder: boolean;
-  featureUpdates: boolean;
 }
 
 export interface PrivacySettings {
@@ -73,12 +68,7 @@ export interface PrivacySettings {
   analyticsOptIn?: boolean;
 }
 
-export interface BackupSettings {
-  autoBackup: boolean;
-  backupInterval: BackupInterval;
-  exportFormat: ExportFormat;
-  cloudSync: boolean;
-}
+export type BackupSettings = Record<string, never>;
 
 export interface ApiKeyStatus {
   hasKey: boolean;
@@ -167,10 +157,7 @@ const defaultSettings: Omit<
     routeColor: "#2563eb",
   },
   notifications: {
-    emailNotifications: true,
     flightReminder: "24h",
-    checkInReminder: true,
-    featureUpdates: true,
   },
   privacy: {
     twoFactorAuth: false,
@@ -179,12 +166,7 @@ const defaultSettings: Omit<
     accountDeletionRequested: false,
     analyticsOptIn: false,
   },
-  backup: {
-    autoBackup: false,
-    backupInterval: "weekly",
-    exportFormat: "json",
-    cloudSync: false,
-  },
+  backup: {},
   apiKeys: null,
   boardingPassParserStrategy: null, // null = auto (LLM wenn verfügbar)
 };
@@ -221,10 +203,9 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({
           privacy: { ...state.privacy, ...updates },
         })),
-      setBackup: (updates) =>
-        set((state) => ({
-          backup: { ...state.backup, ...updates },
-        })),
+      setBackup: (_updates) => {
+        // BackupSettings has no fields; no-op
+      },
       setApiKeys: (status) =>
         set(() => ({
           apiKeys: status,

--- a/frontend/src/store/settingsStore.ts
+++ b/frontend/src/store/settingsStore.ts
@@ -203,7 +203,7 @@ export const useSettingsStore = create<SettingsState>()(
         set((state) => ({
           privacy: { ...state.privacy, ...updates },
         })),
-      setBackup: (_updates) => {
+      setBackup: () => {
         // BackupSettings has no fields; no-op
       },
       setApiKeys: (status) =>


### PR DESCRIPTION
## Summary

- **Ollama config in DB**: Admin can now set Ollama URL, text model, and vision model via the Admin panel. DB values override `OLLAMA_URL`/`OLLAMA_MODEL` env vars (which remain as fallbacks).
- **Backup schedule in DB**: `backupScheduler` now reads `backupEnabled`, `backupInterval`, `backupRetentionDays` from AdminSettings instead of ENV vars. Admin UI gets a new schedule section in Backup Management.
- **Dead settings removed**: Dropped `requireUserApiKeys`, `requireUserFlightApiKeys`, `trainingSeparateModels`, `debugLoggingEnabled`, and the never-referenced `SystemSettings` table. Frontend BackupSection and NotificationsSection pruned of ghost controls that stored to JSON blob but were never read by any service.
- **Timezone actually works**: New `dateUtils.ts` utility with `Intl.DateTimeFormat` + UTC fallback for invalid timezone strings. `FlightsTablePage` now uses the user's stored timezone setting.

## Changes

| Area | What changed |
|------|-------------|
| Prisma schema | +6 fields to AdminSettings (Ollama, Backup), -5 dead fields, drop SystemSettings table |
| Backend routes | New `GET/PUT /admin/backup-settings`, Ollama fields in parser-settings, loggingConfig gate fixed |
| Backend services | `getParserConfig` + `backupScheduler` read from DB with ENV fallback |
| Admin UI | Ollama config section in Parser Settings, Backup schedule section in Backup Management |
| User settings | BackupSection read-only (schedule is admin-only), NotificationsSection trimmed to real fields |
| Frontend store | `BackupSettings` and `NotificationSettings` pruned of dead fields |
| Date formatting | `formatDateInTimezone/DateTime/Time` with invalid-timezone guard, applied in FlightsTable |

## Test Plan

- [ ] Backend: `npx jest --forceExit` — all pass
- [ ] Frontend: `npx vitest --run` — 135/135 pass
- [ ] Backend type check: `npx tsc --noEmit` — 0 errors
- [ ] Frontend type check: `npx tsc --noEmit` — 0 errors
- [ ] Admin panel → Parser Settings → set Ollama URL → save → restart → confirm parser uses new URL
- [ ] Admin panel → Backup Management → enable auto-backup, set interval → save → confirm cron starts
- [ ] User settings → Backup tab → confirm read-only view (no toggles)
- [ ] User settings → Display → change timezone → flights table dates update accordingly