### PR TITLE
feat: flight panel & map interaction — selection, spotlight, tooltip, animation

### DIFF
--- a/docs/superpowers/plans/2026-04-05-flight-panel-map-interaction.md
+++ b/docs/superpowers/plans/2026-04-05-flight-panel-map-interaction.md
@@ -1,0 +1,2315 @@
+# Flight Panel & Map Interaction Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the inline "Letzte Flüge" sidebar with a standalone `FlightPanel` component that groups connecting flights, offers quick actions per entry, and synchronises with a rich map highlight (spotlight + plane animation + tooltip) via a shared Zustand store.
+
+**Architecture:** A new `useFlightSelectionStore` (Zustand) decouples selection state from both the panel and the map. `FlightPanel` is extracted from `DashboardPage` and owns multi-leg grouping logic. `DeckGLMap` subscribes to the store and orchestrates flyTo, spotlight, plane animation, airport pulse, and tooltip rendering.
+
+**Tech Stack:** React 18, Zustand, deck.gl 9, MapLibre GL 5, Framer Motion, Vitest + @testing-library/react
+
+---
+
+## File Map
+
+### New files
+| File | Responsibility |
+|------|---------------|
+| `frontend/src/store/flightSelectionStore.ts` | Zustand store — selectedIds, selectedFlights, highlightMode |
+| `frontend/src/utils/groupFlights.ts` | Pure function — detect multi-leg chains from Flight[] |
+| `frontend/src/components/FlightPanel.tsx` | Panel root — header, grouped list, footer |
+| `frontend/src/components/FlightPanel/FlightEntry.tsx` | Single flight row + hover quick actions + inline stats toggle |
+| `frontend/src/components/FlightPanel/FlightGroupItem.tsx` | Multi-leg wrapper with bracket + group footer |
+| `frontend/src/components/FlightPanel/InlineStats.tsx` | Expandable stats row (distance, duration, CO₂…) |
+| `frontend/src/components/FlightPanel/QuickActions.tsx` | 5-button action bar shown on hover |
+| `frontend/src/components/MapTooltip.tsx` | Absolute-positioned div overlay on map canvas |
+| `frontend/src/__tests__/store/flightSelectionStore.test.ts` | Store unit tests |
+| `frontend/src/__tests__/utils/groupFlights.test.ts` | groupFlights unit tests |
+| `frontend/src/__tests__/components/FlightPanel.test.tsx` | FlightPanel integration tests |
+
+### Modified files
+| File | What changes |
+|------|-------------|
+| `frontend/src/pages/DashboardPage.tsx` | Replace inline panel JSX with `<FlightPanel>`, add `handleDeleteFlight` + `handleDuplicateFlight` |
+| `frontend/src/components/DeckGLMap.tsx` | Subscribe to store; add spotlight layers, flyTo, plane animation, airport pulse, MapTooltip |
+| `frontend/src/components/MapContainer3D.tsx` | Remove `selectedFlightId` prop (now via store), pass `onEdit` down for tooltip |
+
+---
+
+## Task 1: `useFlightSelectionStore`
+
+**Files:**
+- Create: `frontend/src/store/flightSelectionStore.ts`
+- Create: `frontend/src/__tests__/store/flightSelectionStore.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// frontend/src/__tests__/store/flightSelectionStore.test.ts
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+const mockFlight = (id: string): Flight => ({
+  id,
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T13:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+});
+
+describe("useFlightSelectionStore", () => {
+  beforeEach(() => {
+    useFlightSelectionStore.setState({
+      selectedIds: [],
+      selectedFlights: [],
+      highlightMode: null,
+    });
+  });
+
+  it("initializes with empty selection", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    expect(result.current.selectedIds).toEqual([]);
+    expect(result.current.selectedFlights).toEqual([]);
+    expect(result.current.highlightMode).toBeNull();
+  });
+
+  it("sets single selection and highlightMode to 'single'", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    const flight = mockFlight("f1");
+    act(() => result.current.setSelection(["f1"], [flight]));
+    expect(result.current.selectedIds).toEqual(["f1"]);
+    expect(result.current.selectedFlights).toEqual([flight]);
+    expect(result.current.highlightMode).toBe("single");
+  });
+
+  it("sets group selection and highlightMode to 'group' for multiple ids", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    const f1 = mockFlight("f1");
+    const f2 = mockFlight("f2");
+    act(() => result.current.setSelection(["f1", "f2"], [f1, f2]));
+    expect(result.current.selectedIds).toEqual(["f1", "f2"]);
+    expect(result.current.highlightMode).toBe("group");
+  });
+
+  it("clearSelection resets all state", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    act(() => result.current.setSelection(["f1"], [mockFlight("f1")]));
+    act(() => result.current.clearSelection());
+    expect(result.current.selectedIds).toEqual([]);
+    expect(result.current.selectedFlights).toEqual([]);
+    expect(result.current.highlightMode).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd frontend && npx vitest run src/__tests__/store/flightSelectionStore.test.ts
+```
+Expected: `Cannot find module '../../store/flightSelectionStore'`
+
+- [ ] **Step 3: Create the store**
+
+```typescript
+// frontend/src/store/flightSelectionStore.ts
+import { create } from "zustand";
+import type { Flight } from "../types";
+
+interface FlightSelectionState {
+  selectedIds: string[];
+  selectedFlights: Flight[];
+  highlightMode: "single" | "group" | null;
+  setSelection: (ids: string[], flights: Flight[]) => void;
+  clearSelection: () => void;
+}
+
+export const useFlightSelectionStore = create<FlightSelectionState>()((set) => ({
+  selectedIds: [],
+  selectedFlights: [],
+  highlightMode: null,
+  setSelection: (ids, flights) =>
+    set({
+      selectedIds: ids,
+      selectedFlights: flights,
+      highlightMode: ids.length === 0 ? null : ids.length === 1 ? "single" : "group",
+    }),
+  clearSelection: () =>
+    set({ selectedIds: [], selectedFlights: [], highlightMode: null }),
+}));
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/store/flightSelectionStore.test.ts
+```
+Expected: 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/store/flightSelectionStore.ts frontend/src/__tests__/store/flightSelectionStore.test.ts
+git commit -m "feat: add useFlightSelectionStore for map/panel selection sync"
+```
+
+---
+
+## Task 2: `groupFlights` utility
+
+**Files:**
+- Create: `frontend/src/utils/groupFlights.ts`
+- Create: `frontend/src/__tests__/utils/groupFlights.test.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+```typescript
+// frontend/src/__tests__/utils/groupFlights.test.ts
+import { describe, it, expect } from "vitest";
+import { groupFlights } from "../../utils/groupFlights";
+import type { Flight } from "../../types";
+
+function flight(
+  id: string,
+  depIata: string,
+  arrIata: string,
+  depTime: string,
+  arrTime: string,
+  depLat = 48.0,
+  depLon = 11.0,
+  arrLat = 52.0,
+  arrLon = 13.0
+): Flight {
+  return {
+    id,
+    userId: "u1",
+    airline: "LH",
+    flightNumber: id,
+    depIata,
+    arrIata,
+    depLat,
+    depLon,
+    arrLat,
+    arrLon,
+    departureTime: depTime,
+    arrivalTime: arrTime,
+    status: "flown",
+    createdAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("groupFlights", () => {
+  it("returns single group for one flight", () => {
+    const f = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const result = groupFlights([f]);
+    expect(result).toEqual([{ type: "single", flight: f }]);
+  });
+
+  it("groups two connecting flights into multileg", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+    if (result[0].type === "multileg") {
+      expect(result[0].flights).toHaveLength(2);
+      expect(result[0].label).toBe("MUC → FRA → JFK");
+    }
+  });
+
+  it("does NOT group flights with different connecting airport", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "LHR", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("single");
+    expect(result[1].type).toBe("single");
+  });
+
+  it("does NOT group flights with gap > 12h", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T23:30:00Z", "2024-03-15T02:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("groups a three-leg chain", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T08:00:00Z", "2024-03-14T09:00:00Z");
+    const leg2 = flight("f2", "FRA", "LHR", "2024-03-14T11:00:00Z", "2024-03-14T11:45:00Z");
+    const leg3 = flight("f3", "LHR", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2, leg3]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+    if (result[0].type === "multileg") {
+      expect(result[0].flights).toHaveLength(3);
+      expect(result[0].label).toBe("MUC → FRA → LHR → JFK");
+    }
+  });
+
+  it("sorts by departure time before grouping", () => {
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const result = groupFlights([leg2, leg1]); // intentionally reversed
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd frontend && npx vitest run src/__tests__/utils/groupFlights.test.ts
+```
+Expected: `Cannot find module '../../utils/groupFlights'`
+
+- [ ] **Step 3: Create the utility**
+
+```typescript
+// frontend/src/utils/groupFlights.ts
+import type { Flight } from "../types";
+
+export type FlightGroup =
+  | { type: "single"; flight: Flight }
+  | { type: "multileg"; flights: Flight[]; label: string };
+
+const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+
+function buildLabel(flights: Flight[]): string {
+  const codes: string[] = [];
+  for (let i = 0; i < flights.length; i++) {
+    const f = flights[i];
+    if (i === 0) codes.push(f.depIata ?? f.depIcao ?? "?");
+    codes.push(f.arrIata ?? f.arrIcao ?? "?");
+  }
+  return codes.join(" → ");
+}
+
+function connects(a: Flight, b: Flight): boolean {
+  const aArr = a.arrIata ?? a.arrIcao;
+  const bDep = b.depIata ?? b.depIcao;
+  if (!aArr || !bDep || aArr !== bDep) return false;
+  const gapMs =
+    new Date(b.departureTime).getTime() - new Date(a.arrivalTime).getTime();
+  return gapMs >= 0 && gapMs <= TWELVE_HOURS_MS;
+}
+
+export function groupFlights(flights: Flight[]): FlightGroup[] {
+  const sorted = [...flights].sort(
+    (a, b) =>
+      new Date(a.departureTime).getTime() - new Date(b.departureTime).getTime()
+  );
+
+  const groups: FlightGroup[] = [];
+  let i = 0;
+
+  while (i < sorted.length) {
+    const chain: Flight[] = [sorted[i]];
+    while (
+      i + 1 < sorted.length &&
+      connects(chain[chain.length - 1], sorted[i + 1])
+    ) {
+      i++;
+      chain.push(sorted[i]);
+    }
+    if (chain.length === 1) {
+      groups.push({ type: "single", flight: chain[0] });
+    } else {
+      groups.push({
+        type: "multileg",
+        flights: chain,
+        label: buildLabel(chain),
+      });
+    }
+    i++;
+  }
+
+  return groups;
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/utils/groupFlights.test.ts
+```
+Expected: 6 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/groupFlights.ts frontend/src/__tests__/utils/groupFlights.test.ts
+git commit -m "feat: add groupFlights utility for multi-leg detection"
+```
+
+---
+
+## Task 3: `QuickActions` component
+
+**Files:**
+- Create: `frontend/src/components/FlightPanel/QuickActions.tsx`
+
+- [ ] **Step 1: Create component**
+
+```typescript
+// frontend/src/components/FlightPanel/QuickActions.tsx
+import type { Flight } from "../../types";
+
+interface QuickActionsProps {
+  flight: Flight;
+  onEdit: (flight: Flight) => void;
+  onMapFocus: () => void;
+  onStatsToggle: () => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+}
+
+export function QuickActions({
+  flight,
+  onEdit,
+  onMapFocus,
+  onStatsToggle,
+  onDuplicate,
+  onDelete,
+}: QuickActionsProps): JSX.Element {
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    <div
+      className="flex gap-1 items-center flex-shrink-0"
+      onClick={stop}
+      onMouseEnter={stop}
+    >
+      {(
+        [
+          { label: "✏️", title: "Bearbeiten", onClick: () => onEdit(flight) },
+          { label: "🗺️", title: "Auf Map zeigen", onClick: onMapFocus },
+          { label: "📊", title: "Stats", onClick: onStatsToggle },
+          { label: "📋", title: "Duplizieren", onClick: () => onDuplicate(flight) },
+          { label: "🗑️", title: "Löschen", onClick: () => onDelete(flight.id) },
+        ] as const
+      ).map(({ label, title, onClick }) => (
+        <button
+          key={title}
+          onClick={onClick}
+          title={title}
+          className="w-7 h-7 flex items-center justify-center rounded text-sm transition-colors"
+          style={{ background: "var(--bg-surface)" }}
+          type="button"
+          aria-label={title}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```typescript
+// frontend/src/__tests__/components/QuickActions.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuickActions } from "../../components/FlightPanel/QuickActions";
+import type { Flight } from "../../types";
+
+const flight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T13:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+const noop = vi.fn();
+
+describe("QuickActions", () => {
+  it("renders 5 action buttons", () => {
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    expect(screen.getByLabelText("Bearbeiten")).toBeInTheDocument();
+    expect(screen.getByLabelText("Auf Map zeigen")).toBeInTheDocument();
+    expect(screen.getByLabelText("Stats")).toBeInTheDocument();
+    expect(screen.getByLabelText("Duplizieren")).toBeInTheDocument();
+    expect(screen.getByLabelText("Löschen")).toBeInTheDocument();
+  });
+
+  it("calls onEdit with flight when edit clicked", () => {
+    const onEdit = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={onEdit}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Bearbeiten"));
+    expect(onEdit).toHaveBeenCalledWith(flight);
+  });
+
+  it("calls onDelete with flightId when delete clicked", () => {
+    const onDelete = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Löschen"));
+    expect(onDelete).toHaveBeenCalledWith("f1");
+  });
+
+  it("calls onMapFocus when map button clicked", () => {
+    const onMapFocus = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={onMapFocus}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Auf Map zeigen"));
+    expect(onMapFocus).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/QuickActions.test.tsx
+```
+Expected: 4 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/FlightPanel/QuickActions.tsx frontend/src/__tests__/components/QuickActions.test.tsx
+git commit -m "feat: add QuickActions component for FlightPanel hover actions"
+```
+
+---
+
+## Task 4: `InlineStats` component
+
+**Files:**
+- Create: `frontend/src/components/FlightPanel/InlineStats.tsx`
+
+- [ ] **Step 1: Create component**
+
+```typescript
+// frontend/src/components/FlightPanel/InlineStats.tsx
+import { calculateDistance, calculateFlightDuration } from "../../lib/geo";
+import type { Flight } from "../../types";
+
+interface InlineStatsProps {
+  flight: Flight;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return `${h}h ${m}m`;
+}
+
+export function InlineStats({ flight }: InlineStatsProps): JSX.Element {
+  const distanceKm =
+    flight.routeDistance != null
+      ? Math.round(flight.routeDistance)
+      : flight.depLat != null &&
+        flight.depLon != null &&
+        flight.arrLat != null &&
+        flight.arrLon != null
+      ? Math.round(
+          calculateDistance(flight.depLat, flight.depLon, flight.arrLat, flight.arrLon)
+        )
+      : null;
+
+  const durationMin =
+    flight.departureTime && flight.arrivalTime
+      ? calculateFlightDuration(flight.departureTime, flight.arrivalTime)
+      : null;
+
+  const stats: string[] = [];
+  if (distanceKm !== null) stats.push(`${distanceKm.toLocaleString("de-DE")} km`);
+  if (durationMin !== null) stats.push(formatDuration(durationMin));
+  if (flight.seatClass)
+    stats.push(flight.seatClass.replace("_", " "));
+  if (flight.co2Kg != null) stats.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+  if (flight.aircraft) stats.push(flight.aircraft);
+
+  return (
+    <div
+      className="px-4 py-2 text-xs"
+      style={{
+        background: "var(--bg-elevated)",
+        borderBottom: "1px solid var(--color-border)",
+        color: "var(--text-muted)",
+      }}
+    >
+      {stats.join(" · ")}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```typescript
+// frontend/src/__tests__/components/InlineStats.test.tsx
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InlineStats } from "../../components/FlightPanel/InlineStats";
+import type { Flight } from "../../types";
+
+const baseFlight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T19:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("InlineStats", () => {
+  it("shows distance derived from coordinates", () => {
+    render(<InlineStats flight={baseFlight} />);
+    // MUC to JFK is ~8280 km, expect some distance text
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+  });
+
+  it("prefers routeDistance over calculated distance", () => {
+    render(<InlineStats flight={{ ...baseFlight, routeDistance: 9999 }} />);
+    expect(screen.getByText(/9\.999 km/)).toBeInTheDocument();
+  });
+
+  it("shows duration", () => {
+    render(<InlineStats flight={baseFlight} />);
+    expect(screen.getByText(/9h 45m/)).toBeInTheDocument();
+  });
+
+  it("shows CO₂ when present", () => {
+    render(<InlineStats flight={{ ...baseFlight, co2Kg: 0.9 }} />);
+    expect(screen.getByText(/CO₂: 0\.9t/)).toBeInTheDocument();
+  });
+
+  it("shows aircraft when present", () => {
+    render(<InlineStats flight={{ ...baseFlight, aircraft: "A350" }} />);
+    expect(screen.getByText(/A350/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/InlineStats.test.tsx
+```
+Expected: 5 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/FlightPanel/InlineStats.tsx frontend/src/__tests__/components/InlineStats.test.tsx
+git commit -m "feat: add InlineStats component for expandable flight stats row"
+```
+
+---
+
+## Task 5: `FlightEntry` component
+
+**Files:**
+- Create: `frontend/src/components/FlightPanel/FlightEntry.tsx`
+
+- [ ] **Step 1: Create component**
+
+```typescript
+// frontend/src/components/FlightPanel/FlightEntry.tsx
+import { useState } from "react";
+import type { Flight } from "../../types";
+import { QuickActions } from "./QuickActions";
+import { InlineStats } from "./InlineStats";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+
+interface FlightEntryProps {
+  flight: Flight;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+  indented?: boolean;
+}
+
+export function FlightEntry({
+  flight,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  indented = false,
+}: FlightEntryProps): JSX.Element {
+  const [hovered, setHovered] = useState(false);
+  const [statsOpen, setStatsOpen] = useState(false);
+  const { selectedIds, setSelection } = useFlightSelectionStore();
+  const isSelected = selectedIds.includes(flight.id);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setSelection([flight.id], [flight])}
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="w-full text-left py-3 transition-colors border-b flex items-center justify-between gap-2"
+        style={{
+          paddingLeft: indented ? "2rem" : "1rem",
+          paddingRight: "0.75rem",
+          background: isSelected || hovered ? "var(--bg-elevated)" : "transparent",
+          borderLeft: isSelected ? "3px solid var(--accent)" : "3px solid transparent",
+          borderColor: "var(--color-border)",
+        }}
+      >
+        <div className="min-w-0">
+          <div className="font-mono text-sm font-semibold truncate">
+            {flight.depIata ?? flight.depIcao ?? "?"} →{" "}
+            {flight.arrIata ?? flight.arrIcao ?? "?"}
+          </div>
+          <div className="text-xs" style={{ color: "var(--text-muted)" }}>
+            {flight.departureTime
+              ? new Date(flight.departureTime).toLocaleDateString("de-DE")
+              : "Unbekannt"}
+            {flight.flightNumber ? ` · ${flight.flightNumber}` : ""}
+          </div>
+        </div>
+        {hovered && (
+          <QuickActions
+            flight={flight}
+            onEdit={onEdit}
+            onMapFocus={() => setSelection([flight.id], [flight])}
+            onStatsToggle={() => setStatsOpen((s) => !s)}
+            onDuplicate={onDuplicate}
+            onDelete={onDelete}
+          />
+        )}
+      </button>
+      {statsOpen && <InlineStats flight={flight} />}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```typescript
+// frontend/src/__tests__/components/FlightEntry.test.tsx
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FlightEntry } from "../../components/FlightPanel/FlightEntry";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+vi.mock("../../store/flightSelectionStore", () => {
+  const setSelection = vi.fn();
+  const clearSelection = vi.fn();
+  return {
+    useFlightSelectionStore: vi.fn(() => ({
+      selectedIds: [],
+      selectedFlights: [],
+      highlightMode: null,
+      setSelection,
+      clearSelection,
+    })),
+  };
+});
+
+const flight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T19:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("FlightEntry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders route and date", () => {
+    render(
+      <FlightEntry
+        flight={flight}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+    expect(screen.getByText(/14\.03\.2024/)).toBeInTheDocument();
+  });
+
+  it("calls setSelection on click", () => {
+    const { setSelection } = useFlightSelectionStore() as { setSelection: ReturnType<typeof vi.fn> };
+    render(
+      <FlightEntry
+        flight={flight}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(setSelection).toHaveBeenCalledWith(["f1"], [flight]);
+  });
+
+  it("shows stats when stats toggle is clicked", () => {
+    render(
+      <FlightEntry
+        flight={flight}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    // Hover to show quick actions
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.click(screen.getByLabelText("Stats"));
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/FlightEntry.test.tsx
+```
+Expected: 3 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/FlightPanel/FlightEntry.tsx frontend/src/__tests__/components/FlightEntry.test.tsx
+git commit -m "feat: add FlightEntry component with hover quick actions and inline stats"
+```
+
+---
+
+## Task 6: `FlightGroupItem` component
+
+**Files:**
+- Create: `frontend/src/components/FlightPanel/FlightGroupItem.tsx`
+
+- [ ] **Step 1: Create component**
+
+```typescript
+// frontend/src/components/FlightPanel/FlightGroupItem.tsx
+import type { Flight } from "../../types";
+import { FlightEntry } from "./FlightEntry";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import { calculateDistance } from "../../lib/geo";
+
+interface FlightGroupItemProps {
+  flights: Flight[];
+  label: string;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+}
+
+export function FlightGroupItem({
+  flights,
+  label,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: FlightGroupItemProps): JSX.Element {
+  const { setSelection } = useFlightSelectionStore();
+
+  const totalDistanceKm = Math.round(
+    flights.reduce((sum, f) => {
+      if (
+        f.depLat != null &&
+        f.depLon != null &&
+        f.arrLat != null &&
+        f.arrLon != null
+      ) {
+        return sum + calculateDistance(f.depLat, f.depLon, f.arrLat, f.arrLon);
+      }
+      return sum;
+    }, 0)
+  );
+
+  return (
+    <div
+      style={{
+        borderLeft: "2px solid var(--accent)",
+        marginLeft: "0.5rem",
+      }}
+    >
+      {flights.map((f) => (
+        <FlightEntry
+          key={f.id}
+          flight={f}
+          onEdit={onEdit}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+          indented
+        />
+      ))}
+      <button
+        type="button"
+        onClick={() => setSelection(flights.map((f) => f.id), flights)}
+        className="w-full text-left px-3 py-1.5 text-xs transition-colors"
+        style={{
+          background: "var(--bg-surface)",
+          borderBottom: "1px solid var(--color-border)",
+          color: "var(--text-muted)",
+        }}
+      >
+        {label} · {flights.length} Legs · {totalDistanceKm.toLocaleString("de-DE")} km
+      </button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Write tests**
+
+```typescript
+// frontend/src/__tests__/components/FlightGroupItem.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FlightGroupItem } from "../../components/FlightPanel/FlightGroupItem";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+const setSelection = vi.fn();
+vi.mock("../../store/flightSelectionStore", () => ({
+  useFlightSelectionStore: vi.fn(() => ({
+    selectedIds: [],
+    selectedFlights: [],
+    highlightMode: null,
+    setSelection,
+    clearSelection: vi.fn(),
+  })),
+}));
+
+const leg1: Flight = {
+  id: "f1", userId: "u1", airline: "LH", flightNumber: "LH100",
+  depIata: "MUC", arrIata: "FRA",
+  depLat: 48.35, depLon: 11.79, arrLat: 50.03, arrLon: 8.57,
+  departureTime: "2024-03-14T08:00:00Z", arrivalTime: "2024-03-14T09:00:00Z",
+  status: "flown", createdAt: "2024-03-14T00:00:00Z",
+};
+const leg2: Flight = {
+  id: "f2", userId: "u1", airline: "LH", flightNumber: "LH402",
+  depIata: "FRA", arrIata: "JFK",
+  depLat: 50.03, depLon: 8.57, arrLat: 40.64, arrLon: -73.78,
+  departureTime: "2024-03-14T11:00:00Z", arrivalTime: "2024-03-14T14:00:00Z",
+  status: "flown", createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("FlightGroupItem", () => {
+  it("renders both legs", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText("MUC → FRA")).toBeInTheDocument();
+    expect(screen.getByText("FRA → JFK")).toBeInTheDocument();
+  });
+
+  it("shows group label and leg count", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/MUC → FRA → JFK/)).toBeInTheDocument();
+    expect(screen.getByText(/2 Legs/)).toBeInTheDocument();
+  });
+
+  it("calls setSelection with all flight ids on footer click", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText(/MUC → FRA → JFK/));
+    expect(setSelection).toHaveBeenCalledWith(["f1", "f2"], [leg1, leg2]);
+  });
+});
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/FlightGroupItem.test.tsx
+```
+Expected: 3 tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/FlightPanel/FlightGroupItem.tsx frontend/src/__tests__/components/FlightGroupItem.test.tsx
+git commit -m "feat: add FlightGroupItem component for multi-leg visual grouping"
+```
+
+---
+
+## Task 7: `FlightPanel` component
+
+**Files:**
+- Create: `frontend/src/components/FlightPanel.tsx`
+- Create: `frontend/src/__tests__/components/FlightPanel.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/src/__tests__/components/FlightPanel.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FlightPanel } from "../../components/FlightPanel";
+import type { Flight } from "../../types";
+
+vi.mock("../../store/flightSelectionStore", () => ({
+  useFlightSelectionStore: vi.fn(() => ({
+    selectedIds: [],
+    selectedFlights: [],
+    highlightMode: null,
+    setSelection: vi.fn(),
+    clearSelection: vi.fn(),
+  })),
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const flights: Flight[] = [
+  {
+    id: "f1", userId: "u1", airline: "LH", flightNumber: "LH404",
+    depIata: "MUC", arrIata: "JFK",
+    depLat: 48.35, depLon: 11.79, arrLat: 40.64, arrLon: -73.78,
+    departureTime: "2024-03-14T10:00:00Z", arrivalTime: "2024-03-14T19:45:00Z",
+    status: "flown", createdAt: "2024-03-14T00:00:00Z",
+  },
+];
+
+describe("FlightPanel", () => {
+  it("renders flight list when open", () => {
+    render(
+      <FlightPanel
+        flights={flights}
+        totalCount={42}
+        isOpen={true}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+  });
+
+  it("shows total count in header", () => {
+    render(
+      <FlightPanel
+        flights={flights}
+        totalCount={42}
+        isOpen={true}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <FlightPanel
+        flights={flights}
+        totalCount={1}
+        isOpen={false}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/FlightPanel.test.tsx
+```
+Expected: `Cannot find module '../../components/FlightPanel'`
+
+- [ ] **Step 3: Create FlightPanel**
+
+```typescript
+// frontend/src/components/FlightPanel.tsx
+import { useMemo } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { Flight } from "../types";
+import { groupFlights } from "../utils/groupFlights";
+import { FlightEntry } from "./FlightPanel/FlightEntry";
+import { FlightGroupItem } from "./FlightPanel/FlightGroupItem";
+
+interface FlightPanelProps {
+  flights: Flight[];
+  totalCount: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+  onAddFlight: () => void;
+}
+
+export function FlightPanel({
+  flights,
+  totalCount,
+  isOpen,
+  onClose,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onAddFlight,
+}: FlightPanelProps): JSX.Element {
+  const groups = useMemo(() => groupFlights(flights), [flights]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <div
+            className="fixed inset-0 bg-black/40 z-30"
+            onClick={onClose}
+            aria-hidden="true"
+          />
+          <motion.div
+            initial={{ x: -380 }}
+            animate={{ x: 0 }}
+            exit={{ x: -380 }}
+            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            className="fixed left-0 top-14 bottom-0 w-80 z-40 flex flex-col overflow-hidden"
+            style={{
+              background: "rgba(22,27,34,0.95)",
+              backdropFilter: "blur(20px)",
+              borderRight: "1px solid var(--color-border)",
+            }}
+          >
+            {/* Header */}
+            <div
+              className="flex items-center justify-between px-4 py-3 flex-shrink-0"
+              style={{ borderBottom: "1px solid var(--color-border)" }}
+            >
+              <h2 className="text-sm font-semibold flex items-center gap-2">
+                Letzte Flüge
+                <span
+                  className="px-1.5 py-0.5 text-xs rounded-full"
+                  style={{ background: "var(--accent)", color: "white" }}
+                >
+                  {totalCount}
+                </span>
+              </h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Panel schließen"
+                className="text-sm transition-colors"
+                style={{ color: "var(--text-muted)" }}
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* List */}
+            <div className="flex-1 overflow-y-auto">
+              {groups.map((group) =>
+                group.type === "single" ? (
+                  <FlightEntry
+                    key={group.flight.id}
+                    flight={group.flight}
+                    onEdit={onEdit}
+                    onDuplicate={onDuplicate}
+                    onDelete={onDelete}
+                  />
+                ) : (
+                  <FlightGroupItem
+                    key={group.flights[0].id}
+                    flights={group.flights}
+                    label={group.label}
+                    onEdit={onEdit}
+                    onDuplicate={onDuplicate}
+                    onDelete={onDelete}
+                  />
+                )
+              )}
+            </div>
+
+            {/* Footer */}
+            <div
+              className="p-3 flex-shrink-0"
+              style={{ borderTop: "1px solid var(--color-border)" }}
+            >
+              <button
+                type="button"
+                onClick={onAddFlight}
+                className="btn-primary w-full text-sm"
+              >
+                + Flug hinzufügen
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/FlightPanel.test.tsx
+```
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/FlightPanel.tsx frontend/src/__tests__/components/FlightPanel.test.tsx
+git commit -m "feat: add FlightPanel component extracted from DashboardPage"
+```
+
+---
+
+## Task 8: DashboardPage wiring
+
+**Files:**
+- Modify: `frontend/src/pages/DashboardPage.tsx`
+
+- [ ] **Step 1: Add `handleDeleteFlight` and `handleDuplicateFlight` handlers**
+
+Find the `handleUpdateFlight` function in `DashboardPage.tsx` (around line 267). Add these two handlers directly after it:
+
+```typescript
+// Add after handleUpdateFlight (~line 293)
+const pendingDeletes = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+const handleDeleteFlight = useCallback(
+  (flightId: string) => {
+    // Optimistically remove from list immediately
+    setRecentFlights((prev) => prev.filter((f) => f.id !== flightId));
+    setTotalFlightsCount((prev) => prev - 1);
+
+    addToast("info", "Flug gelöscht — wird in 3s entfernt");
+
+    const timer = setTimeout(async () => {
+      pendingDeletes.current.delete(flightId);
+      try {
+        await flightsApi.delete(flightId);
+        loadFlights();
+        const recentData = await flightsApi.getAll({
+          limit: API_LIMITS.RECENT_FLIGHTS,
+          offset: 0,
+        });
+        setRecentFlights(recentData.flights);
+        setTotalFlightsCount(recentData.total);
+      } catch (error) {
+        logger.error("Failed to delete flight:", error);
+        addToast("error", "Fehler beim Löschen des Fluges");
+        // Reload to restore the flight in the list
+        const recentData = await flightsApi.getAll({
+          limit: API_LIMITS.RECENT_FLIGHTS,
+          offset: 0,
+        });
+        setRecentFlights(recentData.flights);
+        setTotalFlightsCount(recentData.total);
+      }
+    }, 3000);
+
+    pendingDeletes.current.set(flightId, timer);
+  },
+  [addToast, loadFlights]
+);
+
+const handleDuplicateFlight = useCallback(
+  async (flight: Flight) => {
+    try {
+      const { id: _id, userId: _uid, createdAt: _ca, ...rest } = flight;
+      void _id; void _uid; void _ca;
+      await flightsApi.create(rest as import("../types").FlightInput);
+      const recentData = await flightsApi.getAll({
+        limit: API_LIMITS.RECENT_FLIGHTS,
+        offset: 0,
+      });
+      setRecentFlights(recentData.flights);
+      setTotalFlightsCount(recentData.total);
+      loadFlights();
+      addToast("success", "Flug dupliziert");
+    } catch (error) {
+      logger.error("Failed to duplicate flight:", error);
+      addToast("error", "Fehler beim Duplizieren");
+    }
+  },
+  [addToast, loadFlights]
+);
+```
+
+Also add the import at the top of the file:
+```typescript
+import { useRef, useCallback } from "react";
+// (add useRef and useCallback to the existing react import)
+```
+
+And import `FlightPanel`:
+```typescript
+import { FlightPanel } from "../components/FlightPanel";
+```
+
+- [ ] **Step 2: Replace the inline left-panel JSX with `<FlightPanel>`**
+
+Find the block starting at `{leftOpen && (` (around line 778) that contains the panel motion.div. Replace the entire block (the `<>` backdrop + `<motion.div>` panel up to and including their closing tags) with:
+
+```typescript
+<FlightPanel
+  flights={recentFlights}
+  totalCount={totalFlightsCount}
+  isOpen={leftOpen}
+  onClose={() => setLeftOpen(false)}
+  onEdit={(flight) => setEditingFlight(flight)}
+  onDuplicate={handleDuplicateFlight}
+  onDelete={handleDeleteFlight}
+  onAddFlight={() => setShowFlightForm(true)}
+/>
+```
+
+- [ ] **Step 3: Remove `selectedFlightId` state — now owned by the store**
+
+Find and remove: `const [selectedFlightId, setSelectedFlightId] = useState<string>();`
+
+Remove `selectedFlightId` and `onFlightClick` props from `<MapContainer3D>` — the map will now read from the store directly. Keep `onFlightClick` wired only if MapContainer3D still needs it for the globe view (check usage).
+
+- [ ] **Step 4: Type-check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Fix any type errors before continuing.
+
+- [ ] **Step 5: Run existing tests**
+
+```bash
+cd frontend && npx vitest run
+```
+Expected: all previously passing tests still pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/pages/DashboardPage.tsx frontend/src/components/FlightPanel.tsx
+git commit -m "feat: wire FlightPanel into DashboardPage, add delete/duplicate handlers"
+```
+
+---
+
+## Task 9: `MapTooltip` component
+
+**Files:**
+- Create: `frontend/src/components/MapTooltip.tsx`
+- Create: `frontend/src/__tests__/components/MapTooltip.test.tsx`
+
+- [ ] **Step 1: Write failing test**
+
+```typescript
+// frontend/src/__tests__/components/MapTooltip.test.tsx
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapTooltip } from "../../components/MapTooltip";
+import type { Flight } from "../../types";
+
+const flight: Flight = {
+  id: "f1", userId: "u1", airline: "Lufthansa", flightNumber: "LH404",
+  depIata: "MUC", arrIata: "JFK", aircraft: "A350",
+  depLat: 48.35, depLon: 11.79, arrLat: 40.64, arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z", arrivalTime: "2024-03-14T19:45:00Z",
+  seatClass: "business", co2Kg: 0.9,
+  status: "flown", createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("MapTooltip", () => {
+  it("renders route header", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+  });
+
+  it("renders airline and flight number", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText(/Lufthansa/)).toBeInTheDocument();
+    expect(screen.getByText(/LH404/)).toBeInTheDocument();
+  });
+
+  it("renders distance and duration", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+    expect(screen.getByText(/h.*m/)).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Bearbeiten is clicked", () => {
+    const onEdit = vi.fn();
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={onEdit} onClose={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText("✏️ Bearbeiten"));
+    expect(onEdit).toHaveBeenCalledWith(flight);
+  });
+
+  it("calls onClose when ✕ is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("✕"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/MapTooltip.test.tsx
+```
+Expected: `Cannot find module '../../components/MapTooltip'`
+
+- [ ] **Step 3: Create MapTooltip**
+
+```typescript
+// frontend/src/components/MapTooltip.tsx
+import { useEffect, useState } from "react";
+import { calculateDistance, calculateFlightDuration } from "../lib/geo";
+import type { Flight } from "../types";
+
+interface MapTooltipProps {
+  flight: Flight;
+  screenX: number;
+  screenY: number;
+  onEdit: (flight: Flight) => void;
+  onClose: () => void;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return `${h}h ${m}m`;
+}
+
+export function MapTooltip({
+  flight,
+  screenX,
+  screenY,
+  onEdit,
+  onClose,
+}: MapTooltipProps): JSX.Element {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  const distanceKm =
+    flight.routeDistance != null
+      ? Math.round(flight.routeDistance)
+      : flight.depLat != null &&
+        flight.depLon != null &&
+        flight.arrLat != null &&
+        flight.arrLon != null
+      ? Math.round(
+          calculateDistance(flight.depLat, flight.depLon, flight.arrLat, flight.arrLon)
+        )
+      : null;
+
+  const durationMin =
+    flight.departureTime && flight.arrivalTime
+      ? calculateFlightDuration(flight.departureTime, flight.arrivalTime)
+      : null;
+
+  const statParts: string[] = [];
+  if (distanceKm !== null) statParts.push(`${distanceKm.toLocaleString("de-DE")} km`);
+  if (durationMin !== null) statParts.push(formatDuration(durationMin));
+  if (flight.seatClass) statParts.push(flight.seatClass.replace("_", " "));
+  if (flight.co2Kg != null) statParts.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: screenX,
+        top: screenY,
+        transform: "translate(-50%, -100%) translateY(-12px)",
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.2s ease",
+        zIndex: 100,
+        pointerEvents: "auto",
+        background: "rgba(15,23,42,0.95)",
+        border: "1px solid var(--accent)",
+        borderRadius: "8px",
+        padding: "0.75rem 1rem",
+        minWidth: "220px",
+        backdropFilter: "blur(12px)",
+        boxShadow: "0 4px 24px rgba(0,0,0,0.4)",
+      }}
+    >
+      <div className="font-mono font-bold text-sm" style={{ color: "var(--accent)" }}>
+        {flight.depIata ?? flight.depIcao ?? "?"} →{" "}
+        {flight.arrIata ?? flight.arrIcao ?? "?"}
+      </div>
+      <div className="text-xs mt-1" style={{ color: "var(--text-muted)" }}>
+        {[
+          flight.airline,
+          flight.flightNumber,
+          flight.aircraft,
+          flight.departureTime
+            ? new Date(flight.departureTime).toLocaleDateString("de-DE")
+            : null,
+        ]
+          .filter(Boolean)
+          .join(" · ")}
+      </div>
+      {statParts.length > 0 && (
+        <div className="text-xs mt-1.5" style={{ color: "var(--text-secondary)" }}>
+          {statParts.join(" · ")}
+        </div>
+      )}
+      <div className="flex gap-2 mt-3">
+        <button
+          type="button"
+          onClick={() => onEdit(flight)}
+          className="text-xs px-2 py-1 rounded transition-colors"
+          style={{ background: "var(--accent)", color: "white" }}
+        >
+          ✏️ Bearbeiten
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs px-2 py-1 rounded transition-colors"
+          style={{
+            background: "var(--bg-elevated)",
+            color: "var(--text-primary)",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/components/MapTooltip.test.tsx
+```
+Expected: 5 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/MapTooltip.tsx frontend/src/__tests__/components/MapTooltip.test.tsx
+git commit -m "feat: add MapTooltip overlay component for map flight info"
+```
+
+---
+
+## Task 10: DeckGLMap — store subscription, flyTo, spotlight/glow
+
+**Files:**
+- Modify: `frontend/src/components/DeckGLMap.tsx`
+- Create: `frontend/src/__tests__/utils/mapAnimationHelpers.test.ts`
+
+- [ ] **Step 1: Add pure helper functions (testable separately)**
+
+Create a new file with the pure geometry helpers:
+
+```typescript
+// frontend/src/utils/mapAnimationHelpers.ts
+
+/**
+ * Compute [west, south, east, north] bounding box for a set of [lon, lat] points.
+ * Returns null if points array is empty.
+ */
+export function computeBbox(
+  points: Array<[number, number]>
+): [number, number, number, number] | null {
+  if (points.length === 0) return null;
+  let minLon = Infinity, maxLon = -Infinity, minLat = Infinity, maxLat = -Infinity;
+  for (const [lon, lat] of points) {
+    if (lon < minLon) minLon = lon;
+    if (lon > maxLon) maxLon = lon;
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+  }
+  return [minLon, minLat, maxLon, maxLat];
+}
+
+/**
+ * Linearly interpolate a position along the arc at progress t (0→1).
+ * Uses a parabolic z to simulate arc height.
+ */
+export function arcPosition(
+  source: [number, number],
+  target: [number, number],
+  t: number
+): [number, number] {
+  return [
+    source[0] + (target[0] - source[0]) * t,
+    source[1] + (target[1] - source[1]) * t,
+  ];
+}
+
+/** Ease-in-out cubic for smooth animation */
+export function easeInOut(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}
+```
+
+- [ ] **Step 2: Write tests for helpers**
+
+```typescript
+// frontend/src/__tests__/utils/mapAnimationHelpers.test.ts
+import { describe, it, expect } from "vitest";
+import { computeBbox, arcPosition, easeInOut } from "../../utils/mapAnimationHelpers";
+
+describe("computeBbox", () => {
+  it("returns null for empty array", () => {
+    expect(computeBbox([])).toBeNull();
+  });
+
+  it("returns tight bbox for two points", () => {
+    const bbox = computeBbox([[11.79, 48.35], [-73.78, 40.64]]);
+    expect(bbox).toEqual([-73.78, 40.64, 11.79, 48.35]);
+  });
+
+  it("handles single point", () => {
+    const bbox = computeBbox([[10, 50]]);
+    expect(bbox).toEqual([10, 50, 10, 50]);
+  });
+});
+
+describe("arcPosition", () => {
+  it("returns source at t=0", () => {
+    expect(arcPosition([0, 0], [10, 10], 0)).toEqual([0, 0]);
+  });
+
+  it("returns target at t=1", () => {
+    expect(arcPosition([0, 0], [10, 10], 1)).toEqual([10, 10]);
+  });
+
+  it("returns midpoint at t=0.5", () => {
+    const [lon, lat] = arcPosition([0, 0], [10, 10], 0.5);
+    expect(lon).toBeCloseTo(5);
+    expect(lat).toBeCloseTo(5);
+  });
+});
+
+describe("easeInOut", () => {
+  it("returns 0 at t=0", () => expect(easeInOut(0)).toBe(0));
+  it("returns 1 at t=1", () => expect(easeInOut(1)).toBe(1));
+  it("returns 0.5 at t=0.5", () => expect(easeInOut(0.5)).toBeCloseTo(0.5));
+  it("is slow at start and end", () => {
+    expect(easeInOut(0.1)).toBeLessThan(0.1);
+    expect(easeInOut(0.9)).toBeGreaterThan(0.9);
+  });
+});
+```
+
+- [ ] **Step 3: Run helper tests — expect PASS**
+
+```bash
+cd frontend && npx vitest run src/__tests__/utils/mapAnimationHelpers.test.ts
+```
+Expected: all pass
+
+- [ ] **Step 4: Add store subscription + flyTo to DeckGLMap**
+
+At the top of `DeckGLMap.tsx`, add imports:
+
+```typescript
+import { useFlightSelectionStore } from "../store/flightSelectionStore";
+import { computeBbox } from "../utils/mapAnimationHelpers";
+```
+
+Inside the `DeckGLMap` function, after the existing `useEffect` for auto-pitch (around line 79), add:
+
+```typescript
+// Subscribe to selection store
+const { selectedIds, selectedFlights, clearSelection } = useFlightSelectionStore();
+
+// FlyTo when selection changes
+useEffect(() => {
+  if (selectedIds.length === 0) return;
+  const map = mapRef.current?.getMap();
+  if (!map) return;
+
+  const points: Array<[number, number]> = selectedFlights.flatMap((f) => {
+    const pts: Array<[number, number]> = [];
+    if (f.depLon != null && f.depLat != null) pts.push([f.depLon, f.depLat]);
+    if (f.arrLon != null && f.arrLat != null) pts.push([f.arrLon, f.arrLat]);
+    return pts;
+  });
+
+  const bbox = computeBbox(points);
+  if (!bbox) return;
+
+  const [west, south, east, north] = bbox;
+  const centerLon = (west + east) / 2;
+  const centerLat = (south + north) / 2;
+
+  // Estimate zoom: larger bbox → lower zoom
+  const lonSpan = east - west;
+  const latSpan = north - south;
+  const span = Math.max(lonSpan, latSpan);
+  const zoom = span < 5 ? 6 : span < 20 ? 4 : span < 60 ? 3 : 2;
+
+  map.flyTo({
+    center: [centerLon, centerLat],
+    zoom,
+    duration: 600,
+    essential: true,
+  });
+}, [selectedIds, selectedFlights]);
+```
+
+- [ ] **Step 5: Add spotlight/glow layers**
+
+In the `layers` useMemo (currently around line 97 of DeckGLMap), update the `"routes"` case:
+
+```typescript
+case "routes": {
+  const baseLayers = createRoutesLayers(
+    flights,
+    minRouteCount,
+    onFlightClick,
+    themeColors,
+    0.3
+  );
+
+  if (selectedIds.length === 0) return baseLayers;
+
+  // Find selected features
+  const selectedFeatures = flights.filter((f) =>
+    selectedIds.includes(f.properties.id)
+  );
+  const nonSelectedFeatures = flights.filter(
+    (f) => !selectedIds.includes(f.properties.id)
+  );
+
+  // Dim non-selected routes
+  const dimmedLayers = createRoutesLayers(
+    nonSelectedFeatures,
+    minRouteCount,
+    onFlightClick,
+    themeColors,
+    0.3
+  ).map((layer) =>
+    layer.clone({ opacity: 0.08, id: `${layer.id}-dimmed` })
+  );
+
+  // Highlighted selected routes (full opacity + glow)
+  const highlightLayers = createRoutesLayers(
+    selectedFeatures,
+    1,
+    onFlightClick,
+    { ...themeColors, arcSourceColor: [129, 140, 248, 255], arcTargetColor: [99, 102, 241, 255] },
+    0.3
+  ).map((layer) =>
+    layer.clone({ id: `${layer.id}-highlight` })
+  );
+
+  // Glow: second wider arc layer for the bloom effect
+  const glowLayers = createRoutesLayers(
+    selectedFeatures,
+    1,
+    undefined,
+    { ...themeColors, arcSourceColor: [129, 140, 248, 100], arcTargetColor: [99, 102, 241, 100] },
+    0.3
+  ).map((layer) =>
+    layer.clone({
+      id: `${layer.id}-glow`,
+      widthMinPixels: 10,
+      opacity: 0.35,
+    })
+  );
+
+  return [...dimmedLayers, ...glowLayers, ...highlightLayers];
+}
+```
+
+Also add `selectedIds` to the `useMemo` dependency array.
+
+- [ ] **Step 6: Handle map click to clear selection**
+
+In the Map component JSX (where `<Map>` is rendered in DeckGLMap, around line 129), add an `onClick` handler:
+
+```typescript
+onClick={(e) => {
+  // Only clear if the click was not on a pickable layer
+  if (!e.features || e.features.length === 0) {
+    clearSelection();
+  }
+}}
+```
+
+Note: deck.gl pickable clicks are handled by the overlay, not MapLibre's `onClick`. So clearing on any MapLibre map click is safe — pickable arc clicks call `onFlightClick` via the overlay and won't bubble to this handler.
+
+- [ ] **Step 7: Type-check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Fix any type errors. Common issues:
+- `layer.clone()` — ArcLayer and ScatterplotLayer from `@deck.gl/layers` support `clone()`. If type errors appear, cast via `as unknown as Layer`.
+- `themeColors` spread — ensure `MapLayerColors` type allows spread.
+
+- [ ] **Step 8: Run frontend tests**
+
+```bash
+cd frontend && npx vitest run
+```
+Expected: all tests pass
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/utils/mapAnimationHelpers.ts \
+        frontend/src/__tests__/utils/mapAnimationHelpers.test.ts \
+        frontend/src/components/DeckGLMap.tsx
+git commit -m "feat: add map spotlight/glow highlight and flyTo on flight selection"
+```
+
+---
+
+## Task 11: DeckGLMap — plane animation
+
+**Files:**
+- Modify: `frontend/src/components/DeckGLMap.tsx`
+
+The plane animation renders a ✈ marker that travels along the selected route(s) for 1.5s, then stays at the destination. On multi-leg it animates leg 1, then leg 2 sequentially.
+
+- [ ] **Step 1: Add plane animation state and rAF loop to DeckGLMap**
+
+Add these imports at the top:
+
+```typescript
+import { TextLayer } from "@deck.gl/layers";
+import { arcPosition, easeInOut } from "../utils/mapAnimationHelpers";
+```
+
+Inside the DeckGLMap function, after the flyTo useEffect, add:
+
+```typescript
+// Plane animation state
+const [planePositions, setPlanePositions] = useState<Array<[number, number]>>([]);
+const animFrameRef = useRef<number | null>(null);
+
+useEffect(() => {
+  // Cancel previous animation
+  if (animFrameRef.current !== null) {
+    cancelAnimationFrame(animFrameRef.current);
+    animFrameRef.current = null;
+  }
+  setPlanePositions([]);
+
+  if (selectedFlights.length === 0) return;
+
+  // Build list of legs to animate: [source, target] per leg
+  const legs: Array<{ source: [number, number]; target: [number, number] }> =
+    selectedFlights
+      .filter(
+        (f) =>
+          f.depLon != null && f.depLat != null && f.arrLon != null && f.arrLat != null
+      )
+      .map((f) => ({
+        source: [f.depLon!, f.depLat!],
+        target: [f.arrLon!, f.arrLat!],
+      }));
+
+  if (legs.length === 0) return;
+
+  const LEG_DURATION = 1500; // ms per leg
+  const DELAY_AFTER_FLYTO = 500; // wait for flyTo to finish
+  const totalDuration = legs.length * LEG_DURATION;
+  let startTime: number | null = null;
+
+  const animate = (ts: number) => {
+    if (startTime === null) startTime = ts;
+    const elapsed = ts - startTime - DELAY_AFTER_FLYTO;
+    if (elapsed < 0) {
+      animFrameRef.current = requestAnimationFrame(animate);
+      return;
+    }
+
+    const positions: Array<[number, number]> = legs.map((leg, i) => {
+      const legStart = i * LEG_DURATION;
+      const legElapsed = elapsed - legStart;
+      if (legElapsed < 0) return leg.source;
+      if (legElapsed >= LEG_DURATION) return leg.target;
+      const t = easeInOut(legElapsed / LEG_DURATION);
+      return arcPosition(leg.source, leg.target, t);
+    });
+
+    setPlanePositions(positions);
+
+    if (elapsed < totalDuration) {
+      animFrameRef.current = requestAnimationFrame(animate);
+    }
+  };
+
+  animFrameRef.current = requestAnimationFrame(animate);
+
+  return () => {
+    if (animFrameRef.current !== null) {
+      cancelAnimationFrame(animFrameRef.current);
+    }
+  };
+}, [selectedFlights]);
+```
+
+- [ ] **Step 2: Add plane TextLayer to layer list**
+
+In the `layers` useMemo, after constructing the final layer array for the `"routes"` case, append the plane layer at the end. Add a new `useMemo` for the plane layer (separate from the main layers memo, since it updates on every animation frame):
+
+```typescript
+const planeLayers = useMemo((): Layer[] => {
+  if (planePositions.length === 0) return [];
+  return [
+    new TextLayer({
+      id: "plane-marker",
+      data: planePositions.map((position, i) => ({ position, index: i })),
+      getText: () => "✈",
+      getPosition: (d: { position: [number, number] }) => d.position,
+      getSize: 20,
+      getColor: [255, 255, 255, 230],
+      getAngle: 0,
+      fontFamily: "Arial, sans-serif",
+      billboard: true,
+    }),
+  ];
+}, [planePositions]);
+```
+
+Then in the `DeckMapboxOverlay` (where layers are passed to the overlay), merge `planeLayers`:
+
+Find the line where the overlay receives layers (around line 135 in DeckGLMap, the `layers` prop on `DeckMapboxOverlay` or `MapboxOverlay`). Change:
+```typescript
+layers={layers}
+```
+to:
+```typescript
+layers={[...layers, ...planeLayers]}
+```
+
+- [ ] **Step 3: Type-check and run tests**
+
+```bash
+cd frontend && npx tsc --noEmit && npx vitest run
+```
+Expected: all tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/components/DeckGLMap.tsx
+git commit -m "feat: add plane animation along selected flight route"
+```
+
+---
+
+## Task 12: DeckGLMap — airport pulse + MapTooltip integration
+
+**Files:**
+- Modify: `frontend/src/components/DeckGLMap.tsx`
+
+- [ ] **Step 1: Add airport pulse layers**
+
+Add pulse state + interval inside the DeckGLMap function, after the plane animation block:
+
+```typescript
+// Airport pulse phase (0, 1, 2 — cycles every 800ms)
+const [pulsePhase, setPulsePhase] = useState(0);
+const pulseIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+useEffect(() => {
+  if (pulseIntervalRef.current) {
+    clearInterval(pulseIntervalRef.current);
+    pulseIntervalRef.current = null;
+  }
+  setPulsePhase(0);
+  if (selectedFlights.length === 0) return;
+
+  pulseIntervalRef.current = setInterval(() => {
+    setPulsePhase((p) => (p + 1) % 3);
+  }, 800);
+
+  return () => {
+    if (pulseIntervalRef.current) clearInterval(pulseIntervalRef.current);
+  };
+}, [selectedFlights]);
+```
+
+Add a pulseLayers memo:
+
+```typescript
+const pulseLayers = useMemo((): Layer[] => {
+  if (selectedFlights.length === 0) return [];
+
+  const airports = selectedFlights.flatMap((f) => {
+    const pts: Array<[number, number]> = [];
+    if (f.depLon != null && f.depLat != null) pts.push([f.depLon, f.depLat]);
+    if (f.arrLon != null && f.arrLat != null) pts.push([f.arrLon, f.arrLat]);
+    return pts;
+  });
+
+  // Deduplicate
+  const seen = new Set<string>();
+  const unique = airports.filter(([lon, lat]) => {
+    const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+
+  const BASE_RADIUS = 80000; // meters
+  const rings = [
+    { multiplier: 1, opacities: [200, 80, 20] },
+    { multiplier: 2, opacities: [80, 200, 80] },
+    { multiplier: 3.5, opacities: [20, 80, 200] },
+  ];
+
+  return rings.map(({ multiplier, opacities }) =>
+    new ScatterplotLayer({
+      id: `pulse-ring-${multiplier}`,
+      data: unique.map((position) => ({ position })),
+      getPosition: (d: { position: [number, number] }) => d.position,
+      getRadius: BASE_RADIUS * multiplier,
+      getFillColor: [0, 0, 0, 0] as [number, number, number, number],
+      getLineColor: [129, 140, 248, opacities[pulsePhase]] as [number, number, number, number],
+      stroked: true,
+      filled: false,
+      lineWidthMinPixels: 1.5,
+      pickable: false,
+    })
+  );
+}, [selectedFlights, pulsePhase]);
+```
+
+Update the layers merge to include pulseLayers:
+```typescript
+layers={[...layers, ...pulseLayers, ...planeLayers]}
+```
+
+- [ ] **Step 2: Add MapTooltip rendering**
+
+The tooltip appears after the plane animation finishes (~1.8s after selection). It is positioned at the screen coordinates of the route midpoint.
+
+Add tooltip state:
+
+```typescript
+const [tooltipVisible, setTooltipVisible] = useState(false);
+const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+```
+
+Add a useEffect that shows the tooltip after 1.8s:
+
+```typescript
+useEffect(() => {
+  setTooltipVisible(false);
+  if (selectedFlights.length === 0) return;
+
+  const timer = setTimeout(() => {
+    const map = mapRef.current?.getMap();
+    if (!map || selectedFlights.length === 0) return;
+
+    const f = selectedFlights[0];
+    if (f.depLon == null || f.arrLon == null) return;
+
+    // Midpoint of first flight
+    const midLon = (f.depLon + f.arrLon) / 2;
+    const midLat = (f.depLat! + f.arrLat!) / 2;
+    const screenPt = map.project([midLon, midLat]);
+    setTooltipPos({ x: screenPt.x, y: screenPt.y });
+    setTooltipVisible(true);
+  }, 1800);
+
+  return () => clearTimeout(timer);
+}, [selectedFlights]);
+```
+
+Add the `onEdit` prop to `DeckGLMapProps`:
+
+```typescript
+interface DeckGLMapProps {
+  flights: GeoJSONFeature[];
+  visMode: VisMode;
+  minRouteCount?: number;
+  selectedFlightId?: string;
+  onFlightClick?: (flightId: string) => void;
+  onEdit?: (flight: Flight) => void;  // ← add this
+}
+```
+
+Import `Flight` type and `MapTooltip`:
+
+```typescript
+import type { Flight } from "../types";
+import { MapTooltip } from "./MapTooltip";
+```
+
+Render the tooltip inside the DeckGLMap return JSX. The map is rendered inside a `<div>` wrapper — add the tooltip as a sibling to the `<Map>` component:
+
+```typescript
+{tooltipVisible && selectedFlights.length > 0 && (
+  <MapTooltip
+    flight={selectedFlights[0] as unknown as Flight}
+    screenX={tooltipPos.x}
+    screenY={tooltipPos.y}
+    onEdit={(flight) => {
+      clearSelection();
+      onEdit?.(flight);
+    }}
+    onClose={() => {
+      clearSelection();
+      setTooltipVisible(false);
+    }}
+  />
+)}
+```
+
+- [ ] **Step 3: Type-check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+cd frontend && npx vitest run
+```
+Expected: all tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/components/DeckGLMap.tsx
+git commit -m "feat: add airport pulse rings and map tooltip to flight selection"
+```
+
+---
+
+## Task 13: MapContainer3D cleanup + DashboardPage `onEdit` wiring
+
+**Files:**
+- Modify: `frontend/src/components/MapContainer3D.tsx`
+- Modify: `frontend/src/pages/DashboardPage.tsx`
+
+- [ ] **Step 1: Update MapContainer3D props**
+
+`selectedFlightId` is no longer needed (store handles it). Add `onEdit` for the tooltip's edit button.
+
+Update the interface in `MapContainer3D.tsx`:
+
+```typescript
+interface MapContainer3DProps {
+  flights: GeoJSONFeature[];
+  onFlightClick?: (flightId: string) => void;
+  visMode: VisMode;
+  onVisModeChange: (mode: VisMode) => void;
+  minRouteCount?: number;
+  filterSlot?: React.ReactNode;
+  onEdit?: (flight: Flight) => void;  // ← add
+}
+```
+
+Remove `selectedFlightId` from the destructured props and from the `<DeckGLMap>` call. Add `onEdit`:
+
+```typescript
+<DeckGLMap
+  flights={flights}
+  onFlightClick={onFlightClick}
+  visMode={visMode}
+  minRouteCount={minRouteCount}
+  onEdit={onEdit}
+/>
+```
+
+- [ ] **Step 2: Update DashboardPage to pass `onEdit` to MapContainer3D**
+
+In `DashboardPage.tsx`, find the `<MapContainer3D>` usage and add `onEdit`:
+
+```typescript
+<MapContainer3D
+  flights={geoFlights}
+  onFlightClick={(id) => {
+    // Still useful for Globe mode — set store selection
+    const flight = recentFlights.find((f) => f.id === id);
+    if (flight) {
+      useFlightSelectionStore.getState().setSelection([id], [flight]);
+    }
+  }}
+  visMode={visMode}
+  onVisModeChange={handleVisModeChange}
+  minRouteCount={filters.minRouteCount ?? 1}
+  filterSlot={...}
+  onEdit={(flight) => setEditingFlight(flight)}
+/>
+```
+
+Add this import at the top:
+```typescript
+import { useFlightSelectionStore } from "../store/flightSelectionStore";
+```
+
+- [ ] **Step 3: Full type-check**
+
+```bash
+cd frontend && npx tsc --noEmit
+```
+Fix any remaining type errors.
+
+- [ ] **Step 4: Run all tests**
+
+```bash
+cd frontend && npx vitest run
+```
+Expected: all previously passing tests still pass + the 20+ new tests added in this plan all pass.
+
+- [ ] **Step 5: Run build check**
+
+```bash
+cd frontend && npx tsc --noEmit && npm run lint
+```
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add frontend/src/components/MapContainer3D.tsx \
+        frontend/src/pages/DashboardPage.tsx
+git commit -m "feat: wire onEdit through MapContainer3D for map tooltip, cleanup selectedFlightId prop"
+```
+
+---
+
+## Spec Coverage Check
+
+| Spec requirement | Covered in |
+|-----------------|-----------|
+| `useFlightSelectionStore` with selectedIds, selectedFlights, highlightMode | Task 1 |
+| `FlightGroup` type + multi-leg detection ≤12h, same airport | Task 2 |
+| QuickActions: Edit, Map, Stats, Duplicate, Delete | Task 3 |
+| InlineStats: distance, duration, seatClass, CO₂, aircraft | Task 4 |
+| FlightEntry: selection on click, hover state, stats toggle | Task 5 |
+| FlightGroupItem: bracket, group footer with label + distance | Task 6 |
+| FlightPanel extracted from DashboardPage | Task 7 |
+| DashboardPage: delete (3s delayed API), duplicate, panel swap | Task 8 |
+| MapTooltip overlay with flight info + Edit/Close buttons | Task 9 |
+| Spotlight: non-selected routes dimmed to 10%, selected glows | Task 10 |
+| FlyTo: camera flies to bbox on selection | Task 10 |
+| Plane animation: rAF loop, eased interpolation, sequential legs | Task 11 |
+| Airport pulse: 3 concentric rings phase-cycled | Task 12 |
+| Tooltip appears after animation (1.8s delay) at arc midpoint | Task 12 |
+| Deselection on map click → clearSelection | Task 10 |
+| Error: missing coords → skip flyTo/animation, tooltip still shows | Task 12 (flyTo guard) |
+| Delete undo: delay API call, optimistic remove from list | Task 8 |

--- a/docs/superpowers/specs/2026-04-05-flight-panel-map-interaction-design.md
+++ b/docs/superpowers/specs/2026-04-05-flight-panel-map-interaction-design.md
@@ -1,0 +1,200 @@
+# Flight Panel & Map Interaction — Design Spec
+
+**Date:** 2026-04-05
+**Status:** Approved for implementation
+
+---
+
+## Overview
+
+Enhance the "Letzte Flüge" sidebar panel with three interconnected features:
+
+1. **Map Highlight** — clicking a flight spotlights it on the map with animation and a tooltip
+2. **Quick Actions** — hover reveals Edit, Map-focus, Stats, Duplicate, Delete per flight entry
+3. **Multi-Leg Grouping** — connecting flights (same day, ≤12h gap, shared airport) are visually grouped in the list and animate together on the map
+
+---
+
+## Architecture
+
+**Approach: New `FlightPanel` component + Zustand selection store**
+
+The existing inline panel JSX in `DashboardPage.tsx` is extracted into a standalone `FlightPanel` component. A new `useFlightSelectionStore` (Zustand) decouples selection state from both panel and map — both subscribe independently, no props-drilling.
+
+### New files
+- `frontend/src/components/FlightPanel.tsx` — panel root, grouping logic
+- `frontend/src/components/FlightPanel/FlightEntry.tsx` — single flight row + quick actions
+- `frontend/src/components/FlightPanel/FlightGroupItem.tsx` — multi-leg group with bracket
+- `frontend/src/components/FlightPanel/InlineStats.tsx` — expandable stats row
+- `frontend/src/components/FlightPanel/QuickActions.tsx` — hover action bar
+- `frontend/src/components/MapTooltip.tsx` — positioned div overlay on map canvas
+- `frontend/src/store/flightSelectionStore.ts` — Zustand store
+- `frontend/src/utils/groupFlights.ts` — multi-leg detection logic
+
+### Modified files
+- `frontend/src/pages/DashboardPage.tsx` — replace inline panel with `<FlightPanel />`
+- `frontend/src/components/DeckGLMap.tsx` — subscribe to store, add highlight + animation layers
+- `frontend/src/components/MapContainer3D.tsx` — render `<MapTooltip />`, handle flyTo
+
+---
+
+## State & Data Model
+
+### `useFlightSelectionStore`
+
+```ts
+interface FlightSelectionState {
+  selectedIds: string[]
+  highlightMode: 'single' | 'group' | null
+  setSelection: (ids: string[]) => void
+  clearSelection: () => void
+}
+```
+
+### `FlightGroup`
+
+```ts
+type FlightGroup =
+  | { type: 'single'; flight: Flight }
+  | { type: 'multileg'; flights: Flight[]; label: string }
+```
+
+`label` is auto-generated: `"MUC → FRA → JFK"` (full routing string).
+
+---
+
+## Multi-Leg Detection (`groupFlights.ts`)
+
+```
+Input: Flight[] sorted by departure_time ASC
+
+Algorithm:
+  For each consecutive pair (A, B):
+    - A.arrivalAirport.iata === B.departureAirport.iata
+    - timeDiff(A.arrival_time, B.departure_time) <= 12h
+  → merge into { type: 'multileg', flights: [A, B], label: "X → Y → Z" }
+
+Chains of 3+ legs are supported (A→B→C→D).
+Output: FlightGroup[]
+```
+
+---
+
+## FlightPanel Component
+
+### Structure
+
+```
+FlightPanel
+├── Header: "Letzte Flüge (N)" + close button
+├── Scrollable list
+│   ├── FlightGroupItem        ← multi-leg
+│   │   ├── FlightEntry (leg 1)  [indented, bracket left]
+│   │   ├── FlightEntry (leg 2)  [indented, bracket left]
+│   │   └── Group footer: "MUC → FRA → JFK · 2 Legs · 9.820 km"
+│   └── FlightEntry            ← single flight
+│       ├── Route + airline + date
+│       ├── QuickActions (visible on hover)
+│       └── InlineStats (visible when expanded)
+└── "+ Flug hinzufügen"
+```
+
+### Multi-Leg Visual Connector
+
+Left bracket via CSS `border-left` on a wrapper div — 2px accent-color line connecting all legs of a group, with a small corner at the bottom leg. The group footer shows the full routing and total distance.
+
+### QuickActions (all five)
+
+| Icon | Action | Behavior |
+|------|--------|----------|
+| ✏️ | Bearbeiten | Calls `onEdit(flight)` → DashboardPage opens EditModal |
+| 🗺️ | Auf Map | `setSelection([flight.id])` — triggers flyTo + animation |
+| 📊 | Stats | Toggles `InlineStats` expanded state (local to entry) |
+| 📋 | Duplizieren | Calls `onDuplicate(flight)` → DashboardPage handles API |
+| 🗑️ | Löschen | Calls `onDelete(flight.id)` + shows Undo-Toast (3s window) |
+
+Actions appear on `onMouseEnter`, hide on `onMouseLeave`. No separate "map" button when entry is clicked directly — clicking the entry row itself also calls `setSelection`.
+
+### InlineStats content
+
+```
+8.280 km  ·  9h 45m  ·  Business
+CO₂: 0,9t  ·  LH 404  ·  A350
+```
+
+Distance via `calculateDistance()` from `lib/geo.ts` (Haversine). Duration via `calculateFlightDuration()` from same file. CO₂ from flight record if available.
+
+---
+
+## Map Highlight & Animation
+
+### Trigger
+
+`useFlightSelectionStore` subscription in `DeckGLMap`. When `selectedIds` changes:
+
+### Animation Sequence
+
+1. **Camera flyTo** (0ms, 500ms duration)
+   Compute bounding box of all selected flights' departure + arrival coordinates. Animate `viewState` to fit bbox with padding. Multi-leg: bbox of all airports in the group.
+
+2. **Spotlight fade** (parallel, 200ms)
+   All non-selected arc layers fade to 10% opacity via a `opacity` prop on the layer. Selected route(s) remain at 100% + a second ArcLayer rendered on top with `widthMinPixels: 8` and 40% opacity as glow effect.
+
+3. **Airport pulse** (parallel with spotlight)
+   Three `ScatterplotLayer`s for each selected airport at radii `r`, `r*2`, `r*3` with opacities `0.8`, `0.4`, `0.15`. A `setInterval` at 800ms cycles through phase offsets to create a pulsing effect. Cleaned up on `clearSelection`.
+
+4. **Plane animation** (starts after flyTo, duration 1.5s)
+   `requestAnimationFrame` loop incrementing `t: 0 → 1`. Position computed via quadratic Bézier matching the ArcLayer's curve:
+   `apex = midpoint elevated by arcHeight`. Rendered as an `IconLayer` or `TextLayer` (✈ emoji). On multi-leg, animates leg 1 then leg 2 sequentially.
+   Plane remains as a static marker at destination after animation completes.
+
+5. **Tooltip fade-in** (when plane reaches destination, ~1.8s after click)
+   `MapTooltip` is a positioned `div` above the map canvas. Position computed via `deck.gl viewport.project([lon, lat])` → screen coordinates of arc midpoint. Content:
+
+   ```
+   ┌─ MUC → JFK ──────────────────────┐
+   │  LH 404 · A350 · 14. Mär 2024    │
+   │  8.280 km · 9h 45m · Business    │
+   │  CO₂: 0,9t                       │
+   │  [✏️ Bearbeiten]  [✕ Schließen]  │
+   └──────────────────────────────────┘
+   ```
+
+### Deselection
+
+Click anywhere on map canvas (not on a route arc) → `clearSelection()` → all effects fade out (200ms), layers return to normal opacity, pulse interval cleared, tooltip unmounted, plane marker removed.
+
+---
+
+## DashboardPage Changes
+
+- Remove inline panel JSX (the `leftOpen` sidebar content)
+- Add `<FlightPanel flights={recentFlights} onEdit={...} onDelete={...} onDuplicate={...} isOpen={leftOpen} onClose={...} />`
+- Remove `selectedFlightId` state — now owned by store
+- `onFlightClick` passed to MapContainer3D still works via store subscription
+
+---
+
+## Error Handling
+
+- If flight has no coordinates (missing lat/lon in GeoJSON) → skip flyTo and animation, tooltip still shows, log warning
+- If duplicate API call fails → show error toast, no optimistic update
+- Delete uses optimistic pattern: API call is delayed 3s via `setTimeout`. If undo is clicked within that window the timeout is cancelled — no API call made. If window expires, the delete API call fires normally.
+
+---
+
+## Testing
+
+- Unit: `groupFlights()` — various edge cases (same-day different airport, >12h gap, 3-leg chain)
+- Unit: `QuickActions` — all 5 actions call correct callbacks
+- Unit: `FlightSelectionStore` — setSelection, clearSelection, highlightMode transitions
+- Integration: clicking FlightEntry → store updates → DeckGLMap receives correct selectedIds
+- Integration: Undo-toast delete flow
+
+---
+
+## Out of Scope
+
+- Manual trip grouping (drag-and-drop) — future feature
+- Round-trip grouping (outbound + return) — future feature
+- Globe mode map highlight — Globe uses react-globe.gl, separate integration; this spec covers DeckGLMap only

--- a/frontend/src/__tests__/components/FlightEntry.test.tsx
+++ b/frontend/src/__tests__/components/FlightEntry.test.tsx
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FlightEntry } from "../../components/FlightPanel/FlightEntry";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+vi.mock("../../store/flightSelectionStore", () => {
+  const setSelection = vi.fn();
+  const clearSelection = vi.fn();
+  return {
+    useFlightSelectionStore: vi.fn(() => ({
+      selectedIds: [],
+      selectedFlights: [],
+      highlightMode: null,
+      setSelection,
+      clearSelection,
+    })),
+  };
+});
+
+const flight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T19:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("FlightEntry", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders route and date", () => {
+    render(
+      <FlightEntry flight={flight} onEdit={vi.fn()} onDuplicate={vi.fn()} onDelete={vi.fn()} />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+    expect(screen.getByText(/14\.3\.2024/)).toBeInTheDocument();
+  });
+
+  it("calls setSelection with flight on click", () => {
+    const { setSelection } = useFlightSelectionStore() as {
+      setSelection: ReturnType<typeof vi.fn>;
+    };
+    render(
+      <FlightEntry flight={flight} onEdit={vi.fn()} onDuplicate={vi.fn()} onDelete={vi.fn()} />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(setSelection).toHaveBeenCalledWith([flight]);
+  });
+
+  it("shows stats when stats toggle is clicked", () => {
+    render(
+      <FlightEntry flight={flight} onEdit={vi.fn()} onDuplicate={vi.fn()} onDelete={vi.fn()} />
+    );
+    // Hover to show quick actions
+    fireEvent.mouseEnter(screen.getByRole("button"));
+    fireEvent.click(screen.getByLabelText("Stats"));
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/FlightEntry.test.tsx
+++ b/frontend/src/__tests__/components/FlightEntry.test.tsx
@@ -49,14 +49,14 @@ describe("FlightEntry", () => {
   });
 
   it("calls setSelection with flight on click", () => {
-    const { setSelection } = useFlightSelectionStore() as {
+    const mockStore = useFlightSelectionStore() as unknown as {
       setSelection: ReturnType<typeof vi.fn>;
     };
     render(
       <FlightEntry flight={flight} onEdit={vi.fn()} onDuplicate={vi.fn()} onDelete={vi.fn()} />
     );
     fireEvent.click(screen.getByRole("button"));
-    expect(setSelection).toHaveBeenCalledWith([flight]);
+    expect(mockStore.setSelection).toHaveBeenCalledWith([flight]);
   });
 
   it("shows stats when stats toggle is clicked", () => {

--- a/frontend/src/__tests__/components/FlightGroupItem.test.tsx
+++ b/frontend/src/__tests__/components/FlightGroupItem.test.tsx
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import { FlightGroupItem } from "../../components/FlightPanel/FlightGroupItem";
-import { useFlightSelectionStore } from "../../store/flightSelectionStore";
 import type { Flight } from "../../types";
 
 const setSelection = vi.fn();

--- a/frontend/src/__tests__/components/FlightGroupItem.test.tsx
+++ b/frontend/src/__tests__/components/FlightGroupItem.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FlightGroupItem } from "../../components/FlightPanel/FlightGroupItem";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+const setSelection = vi.fn();
+vi.mock("../../store/flightSelectionStore", () => ({
+  useFlightSelectionStore: vi.fn(() => ({
+    selectedIds: [],
+    selectedFlights: [],
+    highlightMode: null,
+    setSelection,
+    clearSelection: vi.fn(),
+  })),
+}));
+
+const leg1: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH100",
+  depIata: "MUC",
+  arrIata: "FRA",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrLat: 50.03,
+  arrLon: 8.57,
+  departureTime: "2024-03-14T08:00:00Z",
+  arrivalTime: "2024-03-14T09:00:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+const leg2: Flight = {
+  id: "f2",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH402",
+  depIata: "FRA",
+  arrIata: "JFK",
+  depLat: 50.03,
+  depLon: 8.57,
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T11:00:00Z",
+  arrivalTime: "2024-03-14T14:00:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("FlightGroupItem", () => {
+  it("renders both legs", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText("MUC → FRA")).toBeInTheDocument();
+    expect(screen.getByText("FRA → JFK")).toBeInTheDocument();
+  });
+
+  it("shows group label and leg count", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/MUC → FRA → JFK/)).toBeInTheDocument();
+    expect(screen.getByText(/2 Legs/)).toBeInTheDocument();
+  });
+
+  it("calls setSelection with all flights on footer click", () => {
+    render(
+      <FlightGroupItem
+        flights={[leg1, leg2]}
+        label="MUC → FRA → JFK"
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+      />
+    );
+    fireEvent.click(screen.getByText(/MUC → FRA → JFK/));
+    expect(setSelection).toHaveBeenCalledWith([leg1, leg2]);
+  });
+});

--- a/frontend/src/__tests__/components/FlightPanel.test.tsx
+++ b/frontend/src/__tests__/components/FlightPanel.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { FlightPanel } from "../../components/FlightPanel";
 import type { Flight } from "../../types";
 
@@ -72,6 +73,25 @@ describe("FlightPanel", () => {
       />
     );
     expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("calls onClose when close button is clicked", async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FlightPanel
+        flights={flights}
+        totalCount={1}
+        isOpen={true}
+        onClose={onClose}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    await user.click(screen.getByRole("button", { name: "Panel schließen" }));
+    expect(onClose).toHaveBeenCalledOnce();
   });
 
   it("renders nothing when closed", () => {

--- a/frontend/src/__tests__/components/FlightPanel.test.tsx
+++ b/frontend/src/__tests__/components/FlightPanel.test.tsx
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { FlightPanel } from "../../components/FlightPanel";
+import type { Flight } from "../../types";
+
+vi.mock("../../store/flightSelectionStore", () => ({
+  useFlightSelectionStore: vi.fn(() => ({
+    selectedIds: [],
+    selectedFlights: [],
+    highlightMode: null,
+    setSelection: vi.fn(),
+    clearSelection: vi.fn(),
+  })),
+}));
+
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: ({ children, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+const flights: Flight[] = [
+  {
+    id: "f1",
+    userId: "u1",
+    airline: "LH",
+    flightNumber: "LH404",
+    depIata: "MUC",
+    arrIata: "JFK",
+    depLat: 48.35,
+    depLon: 11.79,
+    arrLat: 40.64,
+    arrLon: -73.78,
+    departureTime: "2024-03-14T10:00:00Z",
+    arrivalTime: "2024-03-14T19:45:00Z",
+    status: "flown",
+    createdAt: "2024-03-14T00:00:00Z",
+  },
+];
+
+describe("FlightPanel", () => {
+  it("renders flight list when open", () => {
+    render(
+      <FlightPanel
+        flights={flights}
+        totalCount={42}
+        isOpen={true}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+  });
+
+  it("shows total count in header", () => {
+    render(
+      <FlightPanel
+        flights={flights}
+        totalCount={42}
+        isOpen={true}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(screen.getByText("42")).toBeInTheDocument();
+  });
+
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <FlightPanel
+        flights={flights}
+        totalCount={1}
+        isOpen={false}
+        onClose={vi.fn()}
+        onEdit={vi.fn()}
+        onDuplicate={vi.fn()}
+        onDelete={vi.fn()}
+        onAddFlight={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/components/InlineStats.test.tsx
+++ b/frontend/src/__tests__/components/InlineStats.test.tsx
@@ -36,8 +36,8 @@ describe("InlineStats", () => {
   });
 
   it("shows CO₂ when present", () => {
-    render(<InlineStats flight={{ ...baseFlight, co2Kg: 0.9 }} />);
-    expect(screen.getByText(/CO₂: 0\.9t/)).toBeInTheDocument();
+    render(<InlineStats flight={{ ...baseFlight, co2Kg: 450 }} />);
+    expect(screen.getByText(/CO₂: 450 kg/)).toBeInTheDocument();
   });
 
   it("shows aircraft when present", () => {

--- a/frontend/src/__tests__/components/InlineStats.test.tsx
+++ b/frontend/src/__tests__/components/InlineStats.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { InlineStats } from "../../components/FlightPanel/InlineStats";
+import type { Flight } from "../../types";
+
+const baseFlight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T19:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("InlineStats", () => {
+  it("shows distance derived from coordinates", () => {
+    render(<InlineStats flight={baseFlight} />);
+    // MUC to JFK is ~8280 km, expect some distance text
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+  });
+
+  it("prefers routeDistance over calculated distance", () => {
+    render(<InlineStats flight={{ ...baseFlight, routeDistance: 9999 }} />);
+    expect(screen.getByText(/9\.999 km/)).toBeInTheDocument();
+  });
+
+  it("shows duration", () => {
+    render(<InlineStats flight={baseFlight} />);
+    expect(screen.getByText(/9h 45m/)).toBeInTheDocument();
+  });
+
+  it("shows CO₂ when present", () => {
+    render(<InlineStats flight={{ ...baseFlight, co2Kg: 0.9 }} />);
+    expect(screen.getByText(/CO₂: 0\.9t/)).toBeInTheDocument();
+  });
+
+  it("shows aircraft when present", () => {
+    render(<InlineStats flight={{ ...baseFlight, aircraft: "A350" }} />);
+    expect(screen.getByText(/A350/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/components/MapTooltip.test.tsx
+++ b/frontend/src/__tests__/components/MapTooltip.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MapTooltip } from "../../components/MapTooltip";
+import type { Flight } from "../../types";
+
+const flight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "Lufthansa",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  arrIata: "JFK",
+  aircraft: "A350",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T19:45:00Z",
+  seatClass: "business",
+  co2Kg: 0.9,
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+describe("MapTooltip", () => {
+  it("renders route header", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText("MUC → JFK")).toBeInTheDocument();
+  });
+
+  it("renders airline and flight number", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText(/Lufthansa/)).toBeInTheDocument();
+    expect(screen.getByText(/LH404/)).toBeInTheDocument();
+  });
+
+  it("renders distance and duration", () => {
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={vi.fn()} />
+    );
+    expect(screen.getByText(/km/)).toBeInTheDocument();
+    expect(screen.getByText(/h.*m/)).toBeInTheDocument();
+  });
+
+  it("calls onEdit when Bearbeiten is clicked", () => {
+    const onEdit = vi.fn();
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={onEdit} onClose={vi.fn()} />
+    );
+    fireEvent.click(screen.getByText("✏️ Bearbeiten"));
+    expect(onEdit).toHaveBeenCalledWith(flight);
+  });
+
+  it("calls onClose when ✕ is clicked", () => {
+    const onClose = vi.fn();
+    render(
+      <MapTooltip flight={flight} screenX={300} screenY={200} onEdit={vi.fn()} onClose={onClose} />
+    );
+    fireEvent.click(screen.getByText("✕"));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/components/QuickActions.test.tsx
+++ b/frontend/src/__tests__/components/QuickActions.test.tsx
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { QuickActions } from "../../components/FlightPanel/QuickActions";
+import type { Flight } from "../../types";
+
+const flight: Flight = {
+  id: "f1",
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T13:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+};
+
+const noop = vi.fn();
+
+describe("QuickActions", () => {
+  it("renders 5 action buttons", () => {
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    expect(screen.getByLabelText("Bearbeiten")).toBeInTheDocument();
+    expect(screen.getByLabelText("Auf Map zeigen")).toBeInTheDocument();
+    expect(screen.getByLabelText("Stats")).toBeInTheDocument();
+    expect(screen.getByLabelText("Duplizieren")).toBeInTheDocument();
+    expect(screen.getByLabelText("Löschen")).toBeInTheDocument();
+  });
+
+  it("calls onEdit with flight when edit clicked", () => {
+    const onEdit = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={onEdit}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Bearbeiten"));
+    expect(onEdit).toHaveBeenCalledWith(flight);
+  });
+
+  it("calls onDelete with flightId when delete clicked", () => {
+    const onDelete = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={noop}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={onDelete}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Löschen"));
+    expect(onDelete).toHaveBeenCalledWith("f1");
+  });
+
+  it("calls onMapFocus when map button clicked", () => {
+    const onMapFocus = vi.fn();
+    render(
+      <QuickActions
+        flight={flight}
+        onEdit={noop}
+        onMapFocus={onMapFocus}
+        onStatsToggle={noop}
+        onDuplicate={noop}
+        onDelete={noop}
+      />
+    );
+    fireEvent.click(screen.getByLabelText("Auf Map zeigen"));
+    expect(onMapFocus).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/src/__tests__/store/flightSelectionStore.test.ts
+++ b/frontend/src/__tests__/store/flightSelectionStore.test.ts
@@ -39,7 +39,7 @@ describe("useFlightSelectionStore", () => {
   it("sets single selection and highlightMode to 'single'", () => {
     const { result } = renderHook(() => useFlightSelectionStore());
     const flight = mockFlight("f1");
-    act(() => result.current.setSelection(["f1"], [flight]));
+    act(() => result.current.setSelection([flight]));
     expect(result.current.selectedIds).toEqual(["f1"]);
     expect(result.current.selectedFlights).toEqual([flight]);
     expect(result.current.highlightMode).toBe("single");
@@ -49,14 +49,15 @@ describe("useFlightSelectionStore", () => {
     const { result } = renderHook(() => useFlightSelectionStore());
     const f1 = mockFlight("f1");
     const f2 = mockFlight("f2");
-    act(() => result.current.setSelection(["f1", "f2"], [f1, f2]));
+    act(() => result.current.setSelection([f1, f2]));
     expect(result.current.selectedIds).toEqual(["f1", "f2"]);
+    expect(result.current.selectedFlights).toEqual([f1, f2]);
     expect(result.current.highlightMode).toBe("group");
   });
 
   it("clearSelection resets all state", () => {
     const { result } = renderHook(() => useFlightSelectionStore());
-    act(() => result.current.setSelection(["f1"], [mockFlight("f1")]));
+    act(() => result.current.setSelection([mockFlight("f1")]));
     act(() => result.current.clearSelection());
     expect(result.current.selectedIds).toEqual([]);
     expect(result.current.selectedFlights).toEqual([]);

--- a/frontend/src/__tests__/store/flightSelectionStore.test.ts
+++ b/frontend/src/__tests__/store/flightSelectionStore.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import type { Flight } from "../../types";
+
+const mockFlight = (id: string): Flight => ({
+  id,
+  userId: "u1",
+  airline: "LH",
+  flightNumber: "LH404",
+  depIata: "MUC",
+  depLat: 48.35,
+  depLon: 11.79,
+  arrIata: "JFK",
+  arrLat: 40.64,
+  arrLon: -73.78,
+  departureTime: "2024-03-14T10:00:00Z",
+  arrivalTime: "2024-03-14T13:45:00Z",
+  status: "flown",
+  createdAt: "2024-03-14T00:00:00Z",
+});
+
+describe("useFlightSelectionStore", () => {
+  beforeEach(() => {
+    useFlightSelectionStore.setState({
+      selectedIds: [],
+      selectedFlights: [],
+      highlightMode: null,
+    });
+  });
+
+  it("initializes with empty selection", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    expect(result.current.selectedIds).toEqual([]);
+    expect(result.current.selectedFlights).toEqual([]);
+    expect(result.current.highlightMode).toBeNull();
+  });
+
+  it("sets single selection and highlightMode to 'single'", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    const flight = mockFlight("f1");
+    act(() => result.current.setSelection(["f1"], [flight]));
+    expect(result.current.selectedIds).toEqual(["f1"]);
+    expect(result.current.selectedFlights).toEqual([flight]);
+    expect(result.current.highlightMode).toBe("single");
+  });
+
+  it("sets group selection and highlightMode to 'group' for multiple ids", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    const f1 = mockFlight("f1");
+    const f2 = mockFlight("f2");
+    act(() => result.current.setSelection(["f1", "f2"], [f1, f2]));
+    expect(result.current.selectedIds).toEqual(["f1", "f2"]);
+    expect(result.current.highlightMode).toBe("group");
+  });
+
+  it("clearSelection resets all state", () => {
+    const { result } = renderHook(() => useFlightSelectionStore());
+    act(() => result.current.setSelection(["f1"], [mockFlight("f1")]));
+    act(() => result.current.clearSelection());
+    expect(result.current.selectedIds).toEqual([]);
+    expect(result.current.selectedFlights).toEqual([]);
+    expect(result.current.highlightMode).toBeNull();
+  });
+});

--- a/frontend/src/__tests__/utils/groupFlights.test.ts
+++ b/frontend/src/__tests__/utils/groupFlights.test.ts
@@ -86,4 +86,38 @@ describe("groupFlights", () => {
     expect(result).toHaveLength(1);
     expect(result[0].type).toBe("multileg");
   });
+
+  it("returns empty array for empty input", () => {
+    expect(groupFlights([])).toEqual([]);
+  });
+
+  it("handles mixed: connecting pair plus unrelated flight", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const unrelated = flight("f3", "LHR", "CDG", "2024-03-15T09:00:00Z", "2024-03-15T10:30:00Z");
+    const result = groupFlights([leg1, leg2, unrelated]);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("multileg");
+    expect(result[1].type).toBe("single");
+    if (result[1].type === "single") {
+      expect(result[1].flight.id).toBe("f3");
+    }
+  });
+
+  it("groups flights at exactly 12h gap boundary", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    // exactly 12h after arrival = 23:00
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T23:00:00Z", "2024-03-15T02:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+  });
+
+  it("does NOT group flights just over 12h gap", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    // 12h + 1 minute after arrival = 23:01
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T23:01:00Z", "2024-03-15T02:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(2);
+  });
 });

--- a/frontend/src/__tests__/utils/groupFlights.test.ts
+++ b/frontend/src/__tests__/utils/groupFlights.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { groupFlights } from "../../utils/groupFlights";
+import type { Flight } from "../../types";
+
+function flight(
+  id: string,
+  depIata: string,
+  arrIata: string,
+  depTime: string,
+  arrTime: string,
+  depLat = 48.0,
+  depLon = 11.0,
+  arrLat = 52.0,
+  arrLon = 13.0
+): Flight {
+  return {
+    id,
+    userId: "u1",
+    airline: "LH",
+    flightNumber: id,
+    depIata,
+    arrIata,
+    depLat,
+    depLon,
+    arrLat,
+    arrLon,
+    departureTime: depTime,
+    arrivalTime: arrTime,
+    status: "flown",
+    createdAt: "2024-01-01T00:00:00Z",
+  };
+}
+
+describe("groupFlights", () => {
+  it("returns single group for one flight", () => {
+    const f = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const result = groupFlights([f]);
+    expect(result).toEqual([{ type: "single", flight: f }]);
+  });
+
+  it("groups two connecting flights into multileg", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+    if (result[0].type === "multileg") {
+      expect(result[0].flights).toHaveLength(2);
+      expect(result[0].label).toBe("MUC → FRA → JFK");
+    }
+  });
+
+  it("does NOT group flights with different connecting airport", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "LHR", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(2);
+    expect(result[0].type).toBe("single");
+    expect(result[1].type).toBe("single");
+  });
+
+  it("does NOT group flights with gap > 12h", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T23:30:00Z", "2024-03-15T02:00:00Z");
+    const result = groupFlights([leg1, leg2]);
+    expect(result).toHaveLength(2);
+  });
+
+  it("groups a three-leg chain", () => {
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T08:00:00Z", "2024-03-14T09:00:00Z");
+    const leg2 = flight("f2", "FRA", "LHR", "2024-03-14T11:00:00Z", "2024-03-14T11:45:00Z");
+    const leg3 = flight("f3", "LHR", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const result = groupFlights([leg1, leg2, leg3]);
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+    if (result[0].type === "multileg") {
+      expect(result[0].flights).toHaveLength(3);
+      expect(result[0].label).toBe("MUC → FRA → LHR → JFK");
+    }
+  });
+
+  it("sorts by departure time before grouping", () => {
+    const leg2 = flight("f2", "FRA", "JFK", "2024-03-14T13:00:00Z", "2024-03-14T16:00:00Z");
+    const leg1 = flight("f1", "MUC", "FRA", "2024-03-14T10:00:00Z", "2024-03-14T11:00:00Z");
+    const result = groupFlights([leg2, leg1]); // intentionally reversed
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe("multileg");
+  });
+});

--- a/frontend/src/__tests__/utils/mapAnimationHelpers.test.ts
+++ b/frontend/src/__tests__/utils/mapAnimationHelpers.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { computeBbox, arcPosition, easeInOut } from "../../utils/mapAnimationHelpers";
+
+describe("computeBbox", () => {
+  it("returns null for empty array", () => {
+    expect(computeBbox([])).toBeNull();
+  });
+
+  it("returns tight bbox for two points", () => {
+    const bbox = computeBbox([
+      [11.79, 48.35],
+      [-73.78, 40.64],
+    ]);
+    expect(bbox).toEqual([-73.78, 40.64, 11.79, 48.35]);
+  });
+
+  it("handles single point", () => {
+    const bbox = computeBbox([[10, 50]]);
+    expect(bbox).toEqual([10, 50, 10, 50]);
+  });
+});
+
+describe("arcPosition", () => {
+  it("returns source at t=0", () => {
+    expect(arcPosition([0, 0], [10, 10], 0)).toEqual([0, 0]);
+  });
+
+  it("returns target at t=1", () => {
+    expect(arcPosition([0, 0], [10, 10], 1)).toEqual([10, 10]);
+  });
+
+  it("returns midpoint at t=0.5", () => {
+    const [lon, lat] = arcPosition([0, 0], [10, 10], 0.5);
+    expect(lon).toBeCloseTo(5);
+    expect(lat).toBeCloseTo(5);
+  });
+});
+
+describe("easeInOut", () => {
+  it("returns 0 at t=0", () => expect(easeInOut(0)).toBe(0));
+  it("returns 1 at t=1", () => expect(easeInOut(1)).toBe(1));
+  it("returns 0.5 at t=0.5", () => expect(easeInOut(0.5)).toBeCloseTo(0.5));
+  it("is slow at start and end", () => {
+    expect(easeInOut(0.1)).toBeLessThan(0.1);
+    expect(easeInOut(0.9)).toBeGreaterThan(0.9);
+  });
+});

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -3,7 +3,7 @@ import Map, { useControl, type MapRef } from "react-map-gl/maplibre";
 import { MapboxOverlay } from "@deck.gl/mapbox";
 import { LightingEffect, AmbientLight, DirectionalLight } from "@deck.gl/core";
 import type { Layer, MapViewState } from "@deck.gl/core";
-import type { GeoJSONFeature } from "../types";
+import type { GeoJSONFeature, Flight } from "../types";
 import type { VisMode } from "../types/visMode";
 import { createRoutesLayers } from "./layers/routesLayer";
 import { createHeatmapLayer } from "./layers/heatmapLayer";
@@ -14,6 +14,10 @@ import { createContourLayer } from "./layers/contourLayer";
 import { TimeSlider } from "./TimeSlider";
 import { useThemeStore } from "../store/themeStore";
 import { MAP_LAYER_COLORS } from "../types/mapTheme";
+import { ScatterplotLayer, TextLayer } from "@deck.gl/layers";
+import { useFlightSelectionStore } from "../store/flightSelectionStore";
+import { computeBbox, arcPosition, easeInOut } from "../utils/mapAnimationHelpers";
+import { MapTooltip } from "./MapTooltip";
 
 const INITIAL_VIEW_STATE: MapViewState = {
   longitude: 10,
@@ -52,8 +56,8 @@ interface DeckGLMapProps {
   flights: GeoJSONFeature[];
   visMode: VisMode;
   minRouteCount?: number;
-  selectedFlightId?: string;
   onFlightClick?: (flightId: string) => void;
+  onEdit?: (flight: Flight) => void;
 }
 
 export function DeckGLMap({
@@ -61,6 +65,7 @@ export function DeckGLMap({
   visMode,
   minRouteCount = 1,
   onFlightClick,
+  onEdit,
 }: DeckGLMapProps): JSX.Element {
   const isDarkMode = useThemeStore((state) => state.isDarkMode);
   const mapTheme = useThemeStore((state) => state.mapTheme);
@@ -69,6 +74,9 @@ export function DeckGLMap({
 
   const [currentTime, setCurrentTime] = useState<number>(0);
   const [playing, setPlaying] = useState<boolean>(false);
+
+  // Store subscription
+  const { selectedIds, selectedFlights, clearSelection } = useFlightSelectionStore();
 
   // Auto-pitch: 3D layers need pitch > 0 to be visible
   useEffect(() => {
@@ -93,10 +101,250 @@ export function DeckGLMap({
     setCurrentTime(timeRange.min);
   }, [timeRange.min]);
 
+  // flyTo when selection changes
+  useEffect(() => {
+    if (selectedIds.length === 0) return;
+    const map = mapRef.current?.getMap();
+    if (!map) return;
+
+    const points: Array<[number, number]> = selectedFlights.flatMap((f) => {
+      const pts: Array<[number, number]> = [];
+      if (f.depLon != null && f.depLat != null) pts.push([f.depLon, f.depLat]);
+      if (f.arrLon != null && f.arrLat != null) pts.push([f.arrLon, f.arrLat]);
+      return pts;
+    });
+
+    const bbox = computeBbox(points);
+    if (!bbox) return;
+
+    const [west, south, east, north] = bbox;
+    const centerLon = (west + east) / 2;
+    const centerLat = (south + north) / 2;
+    const lonSpan = east - west;
+    const latSpan = north - south;
+    const span = Math.max(lonSpan, latSpan);
+    const zoom = span < 5 ? 6 : span < 20 ? 4 : span < 60 ? 3 : 2;
+
+    map.flyTo({ center: [centerLon, centerLat], zoom, duration: 600, essential: true });
+  }, [selectedIds, selectedFlights]);
+
+  // Plane animation
+  const [planePositions, setPlanePositions] = useState<Array<[number, number]>>([]);
+  const animFrameRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (animFrameRef.current !== null) {
+      cancelAnimationFrame(animFrameRef.current);
+      animFrameRef.current = null;
+    }
+    setPlanePositions([]);
+
+    if (selectedFlights.length === 0) return;
+
+    const legs: Array<{ source: [number, number]; target: [number, number] }> = selectedFlights
+      .filter((f) => f.depLon != null && f.depLat != null && f.arrLon != null && f.arrLat != null)
+      .map((f) => ({
+        source: [f.depLon, f.depLat] as [number, number],
+        target: [f.arrLon, f.arrLat] as [number, number],
+      }));
+
+    if (legs.length === 0) return;
+
+    const LEG_DURATION = 1500;
+    const DELAY_AFTER_FLYTO = 500;
+    const totalDuration = legs.length * LEG_DURATION;
+    let startTime: number | null = null;
+
+    const animate = (ts: number): void => {
+      if (startTime === null) startTime = ts;
+      const elapsed = ts - startTime - DELAY_AFTER_FLYTO;
+      if (elapsed < 0) {
+        animFrameRef.current = requestAnimationFrame(animate);
+        return;
+      }
+
+      const positions: Array<[number, number]> = legs.map((leg, i) => {
+        const legStart = i * LEG_DURATION;
+        const legElapsed = elapsed - legStart;
+        if (legElapsed < 0) return leg.source;
+        if (legElapsed >= LEG_DURATION) return leg.target;
+        const t = easeInOut(legElapsed / LEG_DURATION);
+        return arcPosition(leg.source, leg.target, t);
+      });
+
+      setPlanePositions(positions);
+
+      if (elapsed < totalDuration) {
+        animFrameRef.current = requestAnimationFrame(animate);
+      }
+    };
+
+    animFrameRef.current = requestAnimationFrame(animate);
+
+    return () => {
+      if (animFrameRef.current !== null) {
+        cancelAnimationFrame(animFrameRef.current);
+      }
+    };
+  }, [selectedFlights]);
+
+  const planeLayers = useMemo((): Layer[] => {
+    if (planePositions.length === 0) return [];
+    return [
+      new TextLayer({
+        id: "plane-marker",
+        data: planePositions.map((position, i) => ({ position, index: i })),
+        getText: () => "✈",
+        getPosition: (d: { position: [number, number] }) => d.position,
+        getSize: 20,
+        getColor: [255, 255, 255, 230] as [number, number, number, number],
+        getAngle: 0,
+        fontFamily: "Arial, sans-serif",
+        billboard: true,
+      }),
+    ];
+  }, [planePositions]);
+
+  // Airport pulse
+  const [pulsePhase, setPulsePhase] = useState(0);
+  const pulseIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  useEffect(() => {
+    if (pulseIntervalRef.current) {
+      clearInterval(pulseIntervalRef.current);
+      pulseIntervalRef.current = null;
+    }
+    setPulsePhase(0);
+    if (selectedFlights.length === 0) return;
+
+    pulseIntervalRef.current = setInterval(() => {
+      setPulsePhase((p) => (p + 1) % 3);
+    }, 800);
+
+    return () => {
+      if (pulseIntervalRef.current) clearInterval(pulseIntervalRef.current);
+    };
+  }, [selectedFlights]);
+
+  const pulseLayers = useMemo((): Layer[] => {
+    if (selectedFlights.length === 0) return [];
+
+    const pts = selectedFlights.flatMap((f) => {
+      const res: Array<[number, number]> = [];
+      if (f.depLon != null && f.depLat != null) res.push([f.depLon, f.depLat]);
+      if (f.arrLon != null && f.arrLat != null) res.push([f.arrLon, f.arrLat]);
+      return res;
+    });
+
+    const seen = new Set<string>();
+    const unique = pts.filter(([lon, lat]) => {
+      const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    const BASE_RADIUS = 80000;
+    const rings: Array<{ multiplier: number; opacities: [number, number, number] }> = [
+      { multiplier: 1, opacities: [200, 80, 20] },
+      { multiplier: 2, opacities: [80, 200, 80] },
+      { multiplier: 3.5, opacities: [20, 80, 200] },
+    ];
+
+    return rings.map(
+      ({ multiplier, opacities }) =>
+        new ScatterplotLayer({
+          id: `pulse-ring-${multiplier}`,
+          data: unique.map((position) => ({ position })),
+          getPosition: (d: { position: [number, number] }) => d.position,
+          getRadius: BASE_RADIUS * multiplier,
+          getFillColor: [0, 0, 0, 0] as [number, number, number, number],
+          getLineColor: [129, 140, 248, opacities[pulsePhase]] as [number, number, number, number],
+          stroked: true,
+          filled: false,
+          lineWidthMinPixels: 1.5,
+          pickable: false,
+        })
+    );
+  }, [selectedFlights, pulsePhase]);
+
+  // Tooltip state
+  const [tooltipVisible, setTooltipVisible] = useState(false);
+  const [tooltipPos, setTooltipPos] = useState<{ x: number; y: number }>({ x: 0, y: 0 });
+
+  useEffect(() => {
+    setTooltipVisible(false);
+    if (selectedFlights.length === 0) return;
+
+    const timer = setTimeout(() => {
+      const map = mapRef.current?.getMap();
+      if (!map || selectedFlights.length === 0) return;
+
+      const f = selectedFlights[0];
+      if (f.depLon == null || f.arrLon == null || f.depLat == null || f.arrLat == null) return;
+
+      const midLon = (f.depLon + f.arrLon) / 2;
+      const midLat = (f.depLat + f.arrLat) / 2;
+      const screenPt = map.project([midLon, midLat]);
+      setTooltipPos({ x: screenPt.x, y: screenPt.y });
+      setTooltipVisible(true);
+    }, 1800);
+
+    return () => clearTimeout(timer);
+  }, [selectedFlights]);
+
   const layers = useMemo((): Layer[] => {
     switch (visMode) {
-      case "routes":
-        return createRoutesLayers(flights, minRouteCount, onFlightClick, themeColors);
+      case "routes": {
+        const baseLayers = createRoutesLayers(
+          flights,
+          minRouteCount,
+          onFlightClick,
+          themeColors,
+          0.3
+        );
+
+        if (selectedIds.length === 0) return baseLayers;
+
+        const selectedFeatures = flights.filter((f) => selectedIds.includes(f.properties.id));
+        const nonSelectedFeatures = flights.filter((f) => !selectedIds.includes(f.properties.id));
+
+        const dimmedLayers = createRoutesLayers(
+          nonSelectedFeatures,
+          minRouteCount,
+          onFlightClick,
+          themeColors,
+          0.3
+        ).map((layer) =>
+          (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
+            opacity: 0.08,
+            id: `${layer.id}-dimmed`,
+          })
+        );
+
+        const highlightLayers = createRoutesLayers(
+          selectedFeatures,
+          1,
+          onFlightClick,
+          themeColors,
+          0.3
+        ).map((layer) =>
+          (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
+            id: `${layer.id}-highlight`,
+          })
+        );
+
+        const glowLayers = createRoutesLayers(selectedFeatures, 1, undefined, themeColors, 0.3).map(
+          (layer) =>
+            (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
+              id: `${layer.id}-glow`,
+              widthMinPixels: 10,
+              opacity: 0.35,
+            })
+        );
+
+        return [...dimmedLayers, ...glowLayers, ...highlightLayers];
+      }
       case "heatmap":
         return [createHeatmapLayer(flights)];
       case "hexagon":
@@ -110,7 +358,16 @@ export function DeckGLMap({
       default:
         return [];
     }
-  }, [visMode, flights, minRouteCount, trips, currentTime, onFlightClick, themeColors]);
+  }, [
+    visMode,
+    flights,
+    minRouteCount,
+    trips,
+    currentTime,
+    onFlightClick,
+    themeColors,
+    selectedIds,
+  ]);
 
   // Only enable lighting for 3D modes where it makes a visual difference
   const effects = useMemo(
@@ -129,8 +386,11 @@ export function DeckGLMap({
         initialViewState={INITIAL_VIEW_STATE}
         mapStyle={isDarkMode ? DARK_MAP_STYLE : LIGHT_MAP_STYLE}
         style={{ position: "absolute", inset: "0" }}
+        onClick={() => {
+          clearSelection();
+        }}
       >
-        <DeckGLOverlay layers={layers} effects={effects} />
+        <DeckGLOverlay layers={[...layers, ...pulseLayers, ...planeLayers]} effects={effects} />
       </Map>
 
       {/* Subtle grid overlay — glassmorphism dark mode only */}
@@ -156,6 +416,22 @@ export function DeckGLMap({
             onTogglePlay={() => setPlaying((p) => !p)}
           />
         </div>
+      )}
+
+      {tooltipVisible && selectedFlights.length > 0 && (
+        <MapTooltip
+          flight={selectedFlights[0]}
+          screenX={tooltipPos.x}
+          screenY={tooltipPos.y}
+          onEdit={(flight) => {
+            clearSelection();
+            onEdit?.(flight);
+          }}
+          onClose={() => {
+            clearSelection();
+            setTooltipVisible(false);
+          }}
+        />
       )}
     </div>
   );

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -314,12 +314,9 @@ export function DeckGLMap({
           minRouteCount,
           onFlightClick,
           themeColors,
-          0.3
-        ).map((layer) =>
-          (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
-            opacity: 0.08,
-            id: `${layer.id}-dimmed`,
-          })
+          0.3,
+          0.08,
+          "-dimmed"
         );
 
         const highlightLayers = createRoutesLayers(
@@ -327,20 +324,19 @@ export function DeckGLMap({
           1,
           onFlightClick,
           themeColors,
-          0.3
-        ).map((layer) =>
-          (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
-            id: `${layer.id}-highlight`,
-          })
+          0.3,
+          undefined,
+          "-highlight"
         );
 
-        const glowLayers = createRoutesLayers(selectedFeatures, 1, undefined, themeColors, 0.3).map(
-          (layer) =>
-            (layer as unknown as { clone: (props: Record<string, unknown>) => Layer }).clone({
-              id: `${layer.id}-glow`,
-              widthMinPixels: 10,
-              opacity: 0.35,
-            })
+        const glowLayers = createRoutesLayers(
+          selectedFeatures,
+          1,
+          undefined,
+          themeColors,
+          0.3,
+          0.35,
+          "-glow"
         );
 
         return [...dimmedLayers, ...glowLayers, ...highlightLayers];

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -325,7 +325,7 @@ export function DeckGLMap({
           onFlightClick,
           themeColors,
           0.3,
-          undefined,
+          1,
           "-highlight"
         );
 

--- a/frontend/src/components/DeckGLMap.tsx
+++ b/frontend/src/components/DeckGLMap.tsx
@@ -205,68 +205,80 @@ export function DeckGLMap({
     ];
   }, [planePositions]);
 
-  // Airport pulse
-  const [pulsePhase, setPulsePhase] = useState(0);
-  const pulseIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Airport pulse — smooth sine-wave animation via rAF
+  const [pulseTime, setPulseTime] = useState(0);
+  const pulseRafRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (pulseIntervalRef.current) {
-      clearInterval(pulseIntervalRef.current);
-      pulseIntervalRef.current = null;
+    if (pulseRafRef.current !== null) {
+      cancelAnimationFrame(pulseRafRef.current);
+      pulseRafRef.current = null;
     }
-    setPulsePhase(0);
+    setPulseTime(0);
     if (selectedFlights.length === 0) return;
 
-    pulseIntervalRef.current = setInterval(() => {
-      setPulsePhase((p) => (p + 1) % 3);
-    }, 800);
+    const startTime = performance.now();
+    const animate = (ts: number): void => {
+      setPulseTime(ts - startTime);
+      pulseRafRef.current = requestAnimationFrame(animate);
+    };
+    pulseRafRef.current = requestAnimationFrame(animate);
 
     return () => {
-      if (pulseIntervalRef.current) clearInterval(pulseIntervalRef.current);
+      if (pulseRafRef.current !== null) cancelAnimationFrame(pulseRafRef.current);
     };
   }, [selectedFlights]);
 
-  const pulseLayers = useMemo((): Layer[] => {
-    if (selectedFlights.length === 0) return [];
-
+  // Unique dep/arr airport positions for selected flights
+  const pulsePoints = useMemo((): Array<[number, number]> => {
     const pts = selectedFlights.flatMap((f) => {
       const res: Array<[number, number]> = [];
       if (f.depLon != null && f.depLat != null) res.push([f.depLon, f.depLat]);
       if (f.arrLon != null && f.arrLat != null) res.push([f.arrLon, f.arrLat]);
       return res;
     });
-
     const seen = new Set<string>();
-    const unique = pts.filter(([lon, lat]) => {
+    return pts.filter(([lon, lat]) => {
       const key = `${lon.toFixed(4)},${lat.toFixed(4)}`;
       if (seen.has(key)) return false;
       seen.add(key);
       return true;
     });
+  }, [selectedFlights]);
 
-    const BASE_RADIUS = 80000;
-    const rings: Array<{ multiplier: number; opacities: [number, number, number] }> = [
-      { multiplier: 1, opacities: [200, 80, 20] },
-      { multiplier: 2, opacities: [80, 200, 80] },
-      { multiplier: 3.5, opacities: [20, 80, 200] },
+  const pulseLayers = useMemo((): Layer[] => {
+    if (pulsePoints.length === 0) return [];
+
+    // Three rings in pixels (zoom-invariant), each offset by 1/3 period
+    const PERIOD_MS = 1800;
+    const rings: Array<{ radiusPx: number; phaseOffset: number }> = [
+      { radiusPx: 12, phaseOffset: 0 },
+      { radiusPx: 22, phaseOffset: 0.33 },
+      { radiusPx: 36, phaseOffset: 0.66 },
     ];
+    const data = pulsePoints.map((position) => ({ position }));
 
-    return rings.map(
-      ({ multiplier, opacities }) =>
-        new ScatterplotLayer({
-          id: `pulse-ring-${multiplier}`,
-          data: unique.map((position) => ({ position })),
-          getPosition: (d: { position: [number, number] }) => d.position,
-          getRadius: BASE_RADIUS * multiplier,
-          getFillColor: [0, 0, 0, 0] as [number, number, number, number],
-          getLineColor: [129, 140, 248, opacities[pulsePhase]] as [number, number, number, number],
-          stroked: true,
-          filled: false,
-          lineWidthMinPixels: 1.5,
-          pickable: false,
-        })
-    );
-  }, [selectedFlights, pulsePhase]);
+    return rings.map(({ radiusPx, phaseOffset }) => {
+      const phase = (((pulseTime / PERIOD_MS + phaseOffset) % 1) + 1) % 1;
+      // sin² gives a smooth 0→1→0 pulse per period
+      const opacity = Math.sin(phase * Math.PI) ** 2;
+      const alpha = Math.round(opacity * 210) as number;
+
+      return new ScatterplotLayer({
+        id: `pulse-ring-${radiusPx}`,
+        data,
+        getPosition: (d: { position: [number, number] }) => d.position,
+        getRadius: radiusPx,
+        radiusUnits: "pixels",
+        getFillColor: [0, 0, 0, 0] as [number, number, number, number],
+        getLineColor: [129, 140, 248, alpha] as [number, number, number, number],
+        stroked: true,
+        filled: false,
+        lineWidthMinPixels: 1.5,
+        pickable: false,
+      });
+    });
+  }, [pulsePoints, pulseTime]);
 
   // Tooltip state
   const [tooltipVisible, setTooltipVisible] = useState(false);

--- a/frontend/src/components/FlightPanel.tsx
+++ b/frontend/src/components/FlightPanel.tsx
@@ -1,0 +1,111 @@
+import { useMemo } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+import type { Flight } from "../types";
+import { groupFlights } from "../utils/groupFlights";
+import { FlightEntry } from "./FlightPanel/FlightEntry";
+import { FlightGroupItem } from "./FlightPanel/FlightGroupItem";
+
+interface FlightPanelProps {
+  flights: Flight[];
+  totalCount: number;
+  isOpen: boolean;
+  onClose: () => void;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+  onAddFlight: () => void;
+}
+
+export function FlightPanel({
+  flights,
+  totalCount,
+  isOpen,
+  onClose,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  onAddFlight,
+}: FlightPanelProps): JSX.Element {
+  const groups = useMemo(() => groupFlights(flights), [flights]);
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <>
+          <div className="fixed inset-0 bg-black/40 z-30" onClick={onClose} aria-hidden="true" />
+          <motion.div
+            initial={{ x: -380 }}
+            animate={{ x: 0 }}
+            exit={{ x: -380 }}
+            transition={{ type: "spring", stiffness: 300, damping: 30 }}
+            className="fixed left-0 top-14 bottom-0 w-80 z-40 flex flex-col overflow-hidden"
+            style={{
+              background: "rgba(22,27,34,0.95)",
+              backdropFilter: "blur(20px)",
+              borderRight: "1px solid var(--color-border)",
+            }}
+          >
+            {/* Header */}
+            <div
+              className="flex items-center justify-between px-4 py-3 flex-shrink-0"
+              style={{ borderBottom: "1px solid var(--color-border)" }}
+            >
+              <h2 className="text-sm font-semibold flex items-center gap-2">
+                Letzte Flüge
+                <span
+                  className="px-1.5 py-0.5 text-xs rounded-full"
+                  style={{ background: "var(--accent)", color: "white" }}
+                >
+                  {totalCount}
+                </span>
+              </h2>
+              <button
+                type="button"
+                onClick={onClose}
+                aria-label="Panel schließen"
+                className="text-sm transition-colors"
+                style={{ color: "var(--text-muted)" }}
+              >
+                ✕
+              </button>
+            </div>
+
+            {/* List */}
+            <div className="flex-1 overflow-y-auto">
+              {groups.map((group) =>
+                group.type === "single" ? (
+                  <FlightEntry
+                    key={group.flight.id}
+                    flight={group.flight}
+                    onEdit={onEdit}
+                    onDuplicate={onDuplicate}
+                    onDelete={onDelete}
+                  />
+                ) : (
+                  <FlightGroupItem
+                    key={group.flights[0].id}
+                    flights={group.flights}
+                    label={group.label}
+                    onEdit={onEdit}
+                    onDuplicate={onDuplicate}
+                    onDelete={onDelete}
+                  />
+                )
+              )}
+            </div>
+
+            {/* Footer */}
+            <div
+              className="p-3 flex-shrink-0"
+              style={{ borderTop: "1px solid var(--color-border)" }}
+            >
+              <button type="button" onClick={onAddFlight} className="btn-primary w-full text-sm">
+                + Flug hinzufügen
+              </button>
+            </div>
+          </motion.div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/frontend/src/components/FlightPanel/FlightEntry.tsx
+++ b/frontend/src/components/FlightPanel/FlightEntry.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import type { Flight } from "../../types";
+import { QuickActions } from "./QuickActions";
+import { InlineStats } from "./InlineStats";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+
+interface FlightEntryProps {
+  flight: Flight;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+  indented?: boolean;
+}
+
+export function FlightEntry({
+  flight,
+  onEdit,
+  onDuplicate,
+  onDelete,
+  indented = false,
+}: FlightEntryProps): JSX.Element {
+  const [hovered, setHovered] = useState(false);
+  const [statsOpen, setStatsOpen] = useState(false);
+  const { selectedIds, setSelection } = useFlightSelectionStore();
+  const isSelected = selectedIds.includes(flight.id);
+
+  return (
+    <div>
+      <div
+        onMouseEnter={() => setHovered(true)}
+        onMouseLeave={() => setHovered(false)}
+        className="transition-colors border-b flex items-center justify-between gap-2"
+        style={{
+          borderColor: "var(--color-border)",
+          background: isSelected || hovered ? "var(--bg-elevated)" : "transparent",
+        }}
+      >
+        <button
+          type="button"
+          onClick={() => setSelection([flight])}
+          className="w-full text-left py-3 flex items-center justify-between gap-2"
+          style={{
+            paddingLeft: indented ? "2rem" : "1rem",
+            paddingRight: "0.75rem",
+            borderLeft: isSelected ? "3px solid var(--accent)" : "3px solid transparent",
+            background: "transparent",
+            border: "none",
+          }}
+        >
+          <div className="min-w-0">
+            <div className="font-mono text-sm font-semibold truncate">
+              {flight.depIata ?? flight.depIcao ?? "?"} → {flight.arrIata ?? flight.arrIcao ?? "?"}
+            </div>
+            <div className="text-xs" style={{ color: "var(--text-muted)" }}>
+              {flight.departureTime
+                ? new Date(flight.departureTime).toLocaleDateString("de-DE")
+                : "Unbekannt"}
+              {flight.flightNumber ? ` · ${flight.flightNumber}` : ""}
+            </div>
+          </div>
+        </button>
+        {hovered && (
+          <QuickActions
+            flight={flight}
+            onEdit={onEdit}
+            onMapFocus={() => setSelection([flight])}
+            onStatsToggle={() => setStatsOpen((s) => !s)}
+            onDuplicate={onDuplicate}
+            onDelete={onDelete}
+          />
+        )}
+      </div>
+      {statsOpen && <InlineStats flight={flight} />}
+    </div>
+  );
+}

--- a/frontend/src/components/FlightPanel/FlightEntry.tsx
+++ b/frontend/src/components/FlightPanel/FlightEntry.tsx
@@ -42,9 +42,11 @@ export function FlightEntry({
           style={{
             paddingLeft: indented ? "2rem" : "1rem",
             paddingRight: "0.75rem",
+            borderTop: "none",
+            borderRight: "none",
+            borderBottom: "none",
             borderLeft: isSelected ? "3px solid var(--accent)" : "3px solid transparent",
             background: "transparent",
-            border: "none",
           }}
         >
           <div className="min-w-0">

--- a/frontend/src/components/FlightPanel/FlightGroupItem.tsx
+++ b/frontend/src/components/FlightPanel/FlightGroupItem.tsx
@@ -1,0 +1,63 @@
+import type { Flight } from "../../types";
+import { FlightEntry } from "./FlightEntry";
+import { useFlightSelectionStore } from "../../store/flightSelectionStore";
+import { calculateDistance } from "../../lib/geo";
+
+interface FlightGroupItemProps {
+  flights: Flight[];
+  label: string;
+  onEdit: (flight: Flight) => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+}
+
+export function FlightGroupItem({
+  flights,
+  label,
+  onEdit,
+  onDuplicate,
+  onDelete,
+}: FlightGroupItemProps): JSX.Element {
+  const { setSelection } = useFlightSelectionStore();
+
+  const totalDistanceKm = Math.round(
+    flights.reduce((sum, f) => {
+      if (f.depLat != null && f.depLon != null && f.arrLat != null && f.arrLon != null) {
+        return sum + calculateDistance(f.depLat, f.depLon, f.arrLat, f.arrLon);
+      }
+      return sum;
+    }, 0)
+  );
+
+  return (
+    <div
+      style={{
+        borderLeft: "2px solid var(--accent)",
+        marginLeft: "0.5rem",
+      }}
+    >
+      {flights.map((f) => (
+        <FlightEntry
+          key={f.id}
+          flight={f}
+          onEdit={onEdit}
+          onDuplicate={onDuplicate}
+          onDelete={onDelete}
+          indented
+        />
+      ))}
+      <button
+        type="button"
+        onClick={() => setSelection(flights)}
+        className="w-full text-left px-3 py-1.5 text-xs transition-colors"
+        style={{
+          background: "var(--bg-surface)",
+          borderBottom: "1px solid var(--color-border)",
+          color: "var(--text-muted)",
+        }}
+      >
+        {label} · {flights.length} Legs · {totalDistanceKm.toLocaleString("de-DE")} km
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/FlightPanel/FlightGroupItem.tsx
+++ b/frontend/src/components/FlightPanel/FlightGroupItem.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import type { Flight } from "../../types";
 import { FlightEntry } from "./FlightEntry";
 import { useFlightSelectionStore } from "../../store/flightSelectionStore";
@@ -20,13 +21,17 @@ export function FlightGroupItem({
 }: FlightGroupItemProps): JSX.Element {
   const { setSelection } = useFlightSelectionStore();
 
-  const totalDistanceKm = Math.round(
-    flights.reduce((sum, f) => {
-      if (f.depLat != null && f.depLon != null && f.arrLat != null && f.arrLon != null) {
-        return sum + calculateDistance(f.depLat, f.depLon, f.arrLat, f.arrLon);
-      }
-      return sum;
-    }, 0)
+  const totalDistanceKm = useMemo(
+    () =>
+      Math.round(
+        flights.reduce((sum, f) => {
+          if (f.depLat != null && f.depLon != null && f.arrLat != null && f.arrLon != null) {
+            return sum + calculateDistance(f.depLat, f.depLon, f.arrLat, f.arrLon);
+          }
+          return sum;
+        }, 0)
+      ),
+    [flights]
   );
 
   return (

--- a/frontend/src/components/FlightPanel/InlineStats.tsx
+++ b/frontend/src/components/FlightPanel/InlineStats.tsx
@@ -31,7 +31,8 @@ export function InlineStats({ flight }: InlineStatsProps): JSX.Element {
   if (distanceKm !== null) stats.push(`${distanceKm.toLocaleString("de-DE")} km`);
   if (durationMin !== null) stats.push(formatDuration(durationMin));
   if (flight.seatClass) stats.push(flight.seatClass.replace("_", " "));
-  if (flight.co2Kg != null) stats.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+  if (flight.co2Kg != null)
+    stats.push(`CO₂: ${Math.round(flight.co2Kg).toLocaleString("de-DE")} kg`);
   if (flight.aircraft) stats.push(flight.aircraft);
 
   return (

--- a/frontend/src/components/FlightPanel/InlineStats.tsx
+++ b/frontend/src/components/FlightPanel/InlineStats.tsx
@@ -1,0 +1,49 @@
+import { calculateDistance, calculateFlightDuration } from "../../lib/geo";
+import type { Flight } from "../../types";
+
+interface InlineStatsProps {
+  flight: Flight;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return `${h}h ${m}m`;
+}
+
+export function InlineStats({ flight }: InlineStatsProps): JSX.Element {
+  const distanceKm =
+    flight.routeDistance != null
+      ? Math.round(flight.routeDistance)
+      : flight.depLat != null &&
+          flight.depLon != null &&
+          flight.arrLat != null &&
+          flight.arrLon != null
+        ? Math.round(calculateDistance(flight.depLat, flight.depLon, flight.arrLat, flight.arrLon))
+        : null;
+
+  const durationMin =
+    flight.departureTime && flight.arrivalTime
+      ? calculateFlightDuration(flight.departureTime, flight.arrivalTime)
+      : null;
+
+  const stats: string[] = [];
+  if (distanceKm !== null) stats.push(`${distanceKm.toLocaleString("de-DE")} km`);
+  if (durationMin !== null) stats.push(formatDuration(durationMin));
+  if (flight.seatClass) stats.push(flight.seatClass.replace("_", " "));
+  if (flight.co2Kg != null) stats.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+  if (flight.aircraft) stats.push(flight.aircraft);
+
+  return (
+    <div
+      className="px-4 py-2 text-xs"
+      style={{
+        background: "var(--bg-elevated)",
+        borderBottom: "1px solid var(--color-border)",
+        color: "var(--text-muted)",
+      }}
+    >
+      {stats.join(" · ")}
+    </div>
+  );
+}

--- a/frontend/src/components/FlightPanel/QuickActions.tsx
+++ b/frontend/src/components/FlightPanel/QuickActions.tsx
@@ -1,0 +1,47 @@
+import type { Flight } from "../../types";
+
+interface QuickActionsProps {
+  flight: Flight;
+  onEdit: (flight: Flight) => void;
+  onMapFocus: () => void;
+  onStatsToggle: () => void;
+  onDuplicate: (flight: Flight) => void;
+  onDelete: (flightId: string) => void;
+}
+
+export function QuickActions({
+  flight,
+  onEdit,
+  onMapFocus,
+  onStatsToggle,
+  onDuplicate,
+  onDelete,
+}: QuickActionsProps): JSX.Element {
+  const stop = (e: React.MouseEvent) => e.stopPropagation();
+
+  return (
+    <div className="flex gap-1 items-center flex-shrink-0" onClick={stop} onMouseEnter={stop}>
+      {(
+        [
+          { label: "✏️", title: "Bearbeiten", onClick: () => onEdit(flight) },
+          { label: "🗺️", title: "Auf Map zeigen", onClick: onMapFocus },
+          { label: "📊", title: "Stats", onClick: onStatsToggle },
+          { label: "📋", title: "Duplizieren", onClick: () => onDuplicate(flight) },
+          { label: "🗑️", title: "Löschen", onClick: () => onDelete(flight.id) },
+        ] as const
+      ).map(({ label, title, onClick }) => (
+        <button
+          key={title}
+          onClick={onClick}
+          title={title}
+          className="w-7 h-7 flex items-center justify-center rounded text-sm transition-colors"
+          style={{ background: "var(--bg-surface)" }}
+          type="button"
+          aria-label={title}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/frontend/src/components/MapContainer3D.tsx
+++ b/frontend/src/components/MapContainer3D.tsx
@@ -1,7 +1,7 @@
 import React, { lazy, Suspense, useState, useMemo } from "react";
 import { DeckGLMap } from "./DeckGLMap";
 import { VisModeSelector } from "./VisModeSelector";
-import type { GeoJSONFeature } from "../types";
+import type { GeoJSONFeature, Flight } from "../types";
 import type { VisMode } from "../types/visMode";
 import { useTranslation } from "../hooks/useTranslation";
 import { useThemeStore } from "../store/themeStore";
@@ -10,8 +10,8 @@ const GlobeView = lazy(() => import("./GlobeView"));
 
 interface MapContainer3DProps {
   flights: GeoJSONFeature[];
-  selectedFlightId?: string;
   onFlightClick?: (flightId: string) => void;
+  onEdit?: (flight: Flight) => void;
   visMode: VisMode;
   onVisModeChange: (mode: VisMode) => void;
   minRouteCount?: number;
@@ -20,8 +20,8 @@ interface MapContainer3DProps {
 
 export default function MapContainer3D({
   flights,
-  selectedFlightId,
   onFlightClick,
+  onEdit,
   visMode,
   onVisModeChange,
   minRouteCount = 1,
@@ -62,7 +62,6 @@ export default function MapContainer3D({
           >
             <GlobeView
               flights={flights}
-              selectedFlightId={selectedFlightId}
               onFlightClick={onFlightClick}
               minRouteCount={minRouteCount}
             />
@@ -70,8 +69,8 @@ export default function MapContainer3D({
         ) : (
           <DeckGLMap
             flights={flights}
-            selectedFlightId={selectedFlightId}
             onFlightClick={onFlightClick}
+            onEdit={onEdit}
             visMode={visMode}
             minRouteCount={minRouteCount}
           />

--- a/frontend/src/components/MapTooltip.tsx
+++ b/frontend/src/components/MapTooltip.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useState } from "react";
+import { calculateDistance, calculateFlightDuration } from "../lib/geo";
+import type { Flight } from "../types";
+
+interface MapTooltipProps {
+  flight: Flight;
+  screenX: number;
+  screenY: number;
+  onEdit: (flight: Flight) => void;
+  onClose: () => void;
+}
+
+function formatDuration(minutes: number): string {
+  const h = Math.floor(minutes / 60);
+  const m = Math.round(minutes % 60);
+  return `${h}h ${m}m`;
+}
+
+export function MapTooltip({
+  flight,
+  screenX,
+  screenY,
+  onEdit,
+  onClose,
+}: MapTooltipProps): JSX.Element {
+  const [visible, setVisible] = useState(false);
+  useEffect(() => {
+    const t = setTimeout(() => setVisible(true), 50);
+    return () => clearTimeout(t);
+  }, []);
+
+  const distanceKm =
+    flight.routeDistance != null
+      ? Math.round(flight.routeDistance)
+      : flight.depLat != null &&
+          flight.depLon != null &&
+          flight.arrLat != null &&
+          flight.arrLon != null
+        ? Math.round(calculateDistance(flight.depLat, flight.depLon, flight.arrLat, flight.arrLon))
+        : null;
+
+  const durationMin =
+    flight.departureTime && flight.arrivalTime
+      ? calculateFlightDuration(flight.departureTime, flight.arrivalTime)
+      : null;
+
+  const statParts: string[] = [];
+  if (distanceKm !== null) statParts.push(`${distanceKm.toLocaleString("de-DE")} km`);
+  if (durationMin !== null) statParts.push(formatDuration(durationMin));
+  if (flight.seatClass) statParts.push(flight.seatClass.replace("_", " "));
+  if (flight.co2Kg != null) statParts.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+
+  const departureDate = flight.departureTime
+    ? new Date(flight.departureTime).toLocaleDateString("de-DE")
+    : null;
+
+  const metaParts: string[] = [
+    flight.airline ?? null,
+    flight.flightNumber ?? null,
+    flight.aircraft ?? null,
+    departureDate,
+  ].filter((x): x is string => x !== null && x !== undefined);
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        left: screenX,
+        top: screenY,
+        transform: "translate(-50%, -100%) translateY(-12px)",
+        opacity: visible ? 1 : 0,
+        transition: "opacity 0.2s ease",
+        zIndex: 100,
+        pointerEvents: "auto",
+        background: "rgba(15,23,42,0.95)",
+        border: "1px solid var(--accent)",
+        borderRadius: "8px",
+        padding: "0.75rem 1rem",
+        minWidth: "220px",
+        backdropFilter: "blur(12px)",
+        boxShadow: "0 4px 24px rgba(0,0,0,0.4)",
+      }}
+    >
+      <div className="font-mono font-bold text-sm" style={{ color: "var(--accent)" }}>
+        {flight.depIata ?? flight.depIcao ?? "?"} → {flight.arrIata ?? flight.arrIcao ?? "?"}
+      </div>
+      {metaParts.length > 0 && (
+        <div className="text-xs mt-1" style={{ color: "var(--text-muted)" }}>
+          {metaParts.join(" · ")}
+        </div>
+      )}
+      {statParts.length > 0 && (
+        <div className="text-xs mt-1.5" style={{ color: "var(--text-secondary)" }}>
+          {statParts.join(" · ")}
+        </div>
+      )}
+      <div className="flex gap-2 mt-3">
+        <button
+          type="button"
+          onClick={() => onEdit(flight)}
+          className="text-xs px-2 py-1 rounded transition-colors"
+          style={{ background: "var(--accent)", color: "white" }}
+        >
+          ✏️ Bearbeiten
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-xs px-2 py-1 rounded transition-colors"
+          style={{
+            background: "var(--bg-elevated)",
+            color: "var(--text-primary)",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/MapTooltip.tsx
+++ b/frontend/src/components/MapTooltip.tsx
@@ -48,7 +48,8 @@ export function MapTooltip({
   if (distanceKm !== null) statParts.push(`${distanceKm.toLocaleString("de-DE")} km`);
   if (durationMin !== null) statParts.push(formatDuration(durationMin));
   if (flight.seatClass) statParts.push(flight.seatClass.replace("_", " "));
-  if (flight.co2Kg != null) statParts.push(`CO₂: ${flight.co2Kg.toFixed(1)}t`);
+  if (flight.co2Kg != null)
+    statParts.push(`CO₂: ${Math.round(flight.co2Kg).toLocaleString("de-DE")} kg`);
 
   const departureDate = flight.departureTime
     ? new Date(flight.departureTime).toLocaleDateString("de-DE")

--- a/frontend/src/components/layers/routesLayer.ts
+++ b/frontend/src/components/layers/routesLayer.ts
@@ -100,7 +100,7 @@ export function createRoutesLayers(
   onFlightClick?: (flightId: string) => void,
   themeColors?: MapLayerColors,
   arcHeight: number = 1,
-  opacity?: number,
+  opacity: number = 1,
   idSuffix: string = ""
 ): Layer[] {
   const { arcs, points } = buildRouteData(flights, minRouteCount, themeColors);

--- a/frontend/src/components/layers/routesLayer.ts
+++ b/frontend/src/components/layers/routesLayer.ts
@@ -98,21 +98,26 @@ export function createRoutesLayers(
   flights: GeoJSONFeature[],
   minRouteCount: number,
   onFlightClick?: (flightId: string) => void,
-  themeColors?: MapLayerColors
+  themeColors?: MapLayerColors,
+  arcHeight: number = 1,
+  opacity?: number,
+  idSuffix: string = ""
 ): Layer[] {
   const { arcs, points } = buildRouteData(flights, minRouteCount, themeColors);
   const dotRgb = themeColors?.airportDot ?? ([232, 160, 69] as [number, number, number]);
 
   // Arc width scales with route frequency — dominant corridors are visually thicker
   const arcLayer = new ArcLayer<ArcDatum>({
-    id: "routes-arc",
+    id: `routes-arc${idSuffix}`,
     data: arcs,
     getSourcePosition: (d) => d.sourcePosition,
     getTargetPosition: (d) => d.targetPosition,
     getSourceColor: (d) => d.sourceColor,
     getTargetColor: (d) => d.targetColor,
     getWidth: (d) => Math.min(Math.sqrt(d.count) * 1.3, 7),
+    getHeight: arcHeight,
     widthMinPixels: 1,
+    opacity,
     pickable: !!onFlightClick,
     onClick: onFlightClick
       ? ({ object }) => {
@@ -124,7 +129,7 @@ export function createRoutesLayers(
 
   // Inner ring — close to the airport dot
   const ringInnerLayer = new ScatterplotLayer<PointDatum>({
-    id: "routes-ring-inner",
+    id: `routes-ring-inner${idSuffix}`,
     data: points,
     getPosition: (d) => d.position,
     getRadius: (d) => Math.min(3 + d.count * 0.4, 10) * 1000,
@@ -133,12 +138,13 @@ export function createRoutesLayers(
     stroked: true,
     filled: false,
     lineWidthMinPixels: 1.2,
+    opacity,
     pickable: false,
   });
 
   // Outer ring — faint halo
   const ringOuterLayer = new ScatterplotLayer<PointDatum>({
-    id: "routes-ring-outer",
+    id: `routes-ring-outer${idSuffix}`,
     data: points,
     getPosition: (d) => d.position,
     getRadius: (d) => Math.min(3 + d.count * 0.4, 10) * 1800,
@@ -147,23 +153,25 @@ export function createRoutesLayers(
     stroked: true,
     filled: false,
     lineWidthMinPixels: 0.8,
+    opacity,
     pickable: false,
   });
 
   // Inner dot — solid center marker
   const dotLayer = new ScatterplotLayer<PointDatum>({
-    id: "routes-dot",
+    id: `routes-dot${idSuffix}`,
     data: points,
     getPosition: (d) => d.position,
     getRadius: () => 2200,
     getFillColor: [...dotRgb, 220] as [number, number, number, number],
     stroked: false,
+    opacity,
     pickable: false,
   });
 
   // IATA code labels — appear above each marker
   const labelLayer = new TextLayer<PointDatum>({
-    id: "routes-labels",
+    id: `routes-labels${idSuffix}`,
     data: points,
     getPosition: (d) => d.position,
     getText: (d) => d.iata,
@@ -177,6 +185,7 @@ export function createRoutesLayers(
     getPixelOffset: [0, -18],
     billboard: true,
     characterSet: "auto",
+    opacity,
     parameters: { depthCompare: "always" as const },
   });
 

--- a/frontend/src/i18n/resources/de/dashboard.json
+++ b/frontend/src/i18n/resources/de/dashboard.json
@@ -44,6 +44,7 @@
     "addFlight": "Fehler beim Hinzufügen des Fluges. Bitte versuchen Sie es erneut.",
     "updateFlight": "Fehler beim Aktualisieren des Fluges. Bitte versuchen Sie es erneut.",
     "deleteFlight": "Fehler beim Löschen des Fluges. Bitte versuchen Sie es erneut.",
+    "duplicateFlight": "Fehler beim Duplizieren",
     "loadFlights": "Fehler beim Laden der Flüge",
     "exportFailed": "Export fehlgeschlagen",
     "importFailed": "Import fehlgeschlagen",
@@ -52,7 +53,9 @@
   "success": {
     "flightAdded": "Flug erfolgreich hinzugefügt",
     "flightUpdated": "Flug erfolgreich aktualisiert",
-    "flightDeleted": "Flug erfolgreich gelöscht"
+    "flightDeleted": "Flug erfolgreich gelöscht",
+    "flightDeletedPending": "Flug gelöscht",
+    "flightDuplicated": "Flug dupliziert"
   },
   "navigation": {
     "title": "Navigation"

--- a/frontend/src/i18n/resources/en/dashboard.json
+++ b/frontend/src/i18n/resources/en/dashboard.json
@@ -44,6 +44,7 @@
     "addFlight": "Error adding flight. Please try again.",
     "updateFlight": "Error updating flight. Please try again.",
     "deleteFlight": "Error deleting flight. Please try again.",
+    "duplicateFlight": "Error duplicating flight",
     "loadFlights": "Failed to load flights",
     "exportFailed": "Export failed",
     "importFailed": "Import failed",
@@ -52,7 +53,9 @@
   "success": {
     "flightAdded": "Flight added successfully",
     "flightUpdated": "Flight updated successfully",
-    "flightDeleted": "Flight deleted successfully"
+    "flightDeleted": "Flight deleted successfully",
+    "flightDeletedPending": "Flight deleted",
+    "flightDuplicated": "Flight duplicated"
   },
   "navigation": {
     "title": "Navigation"

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import type { VisMode } from "../types/visMode";
 
 import { useAuthStore } from "../store/authStore";
@@ -22,6 +22,7 @@ import { useSettingsStore } from "../store/settingsStore";
 import { API_LIMITS, STORAGE_KEYS } from "../lib/constants";
 import { toCsv, escapeXml, downloadBlob } from "../lib/export";
 import { motion, AnimatePresence } from "framer-motion";
+import { FlightPanel } from "../components/FlightPanel";
 // jsPDF and autoTable are dynamically imported when needed to reduce bundle size
 
 export default function DashboardPage(): JSX.Element {
@@ -31,12 +32,11 @@ export default function DashboardPage(): JSX.Element {
   const [recentFlights, setRecentFlights] = useState<Flight[]>([]); // Unfiltered recent flights for sidebar
   const [totalFlightsCount, setTotalFlightsCount] = useState(0); // Total number of all flights
   const [geoFlights, setGeoFlights] = useState<GeoJSONFeature[]>([]);
-  const [selectedFlightId, setSelectedFlightId] = useState<string>();
   const [showFlightForm, setShowFlightForm] = useState(false);
   const [editingFlight, setEditingFlight] = useState<Flight | null>(null);
   const [filters, setFilters] = useState<FlightFilters>({});
   const [, setLoadingMap] = useState(true); // Loading indicator for map
-  const [loadingRecent, setLoadingRecent] = useState(true);
+  const [, setLoadingRecent] = useState(true);
   const [visMode, setVisMode] = useState<VisMode>("routes");
   const importInputRef = useRef<HTMLInputElement | null>(null);
 
@@ -291,6 +291,105 @@ export default function DashboardPage(): JSX.Element {
       throw error;
     }
   };
+
+  const pendingDeletes = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+  const handleDeleteFlight = useCallback(
+    (flightId: string) => {
+      setRecentFlights((prev) => prev.filter((f) => f.id !== flightId));
+      setTotalFlightsCount((prev) => prev - 1);
+      addToast("info", "Flug gelöscht");
+
+      const timer = setTimeout(() => {
+        pendingDeletes.current.delete(flightId);
+        void (async () => {
+          try {
+            await flightsApi.delete(flightId);
+            loadFlights();
+            const recentData = await flightsApi.getAll({
+              limit: API_LIMITS.RECENT_FLIGHTS,
+              offset: 0,
+            });
+            setRecentFlights(recentData.flights);
+            setTotalFlightsCount(recentData.total);
+          } catch (error) {
+            logger.error("Failed to delete flight:", error);
+            addToast("error", "Fehler beim Löschen des Fluges");
+            const recentData = await flightsApi.getAll({
+              limit: API_LIMITS.RECENT_FLIGHTS,
+              offset: 0,
+            });
+            setRecentFlights(recentData.flights);
+            setTotalFlightsCount(recentData.total);
+          }
+        })();
+      }, 3000);
+
+      pendingDeletes.current.set(flightId, timer);
+    },
+    [addToast, loadFlights]
+  );
+
+  const handleDuplicateFlight = useCallback(
+    async (flight: Flight): Promise<void> => {
+      try {
+        const input: FlightInput = {
+          airline: flight.airline,
+          flightNumber: flight.flightNumber,
+          callsign: flight.callsign,
+          aircraft: flight.aircraft,
+          departure: {
+            iata: flight.depIata,
+            icao: flight.depIcao,
+            name: flight.depName,
+            lat: flight.depLat,
+            lon: flight.depLon,
+          },
+          arrival: {
+            iata: flight.arrIata,
+            icao: flight.arrIcao,
+            name: flight.arrName,
+            lat: flight.arrLat,
+            lon: flight.arrLon,
+          },
+          departureTime: flight.departureTime,
+          arrivalTime: flight.arrivalTime,
+          status: flight.status,
+          notes: flight.notes,
+          seatNumber: flight.seatNumber,
+          seatClass: flight.seatClass,
+          boardingGroup: flight.boardingGroup,
+          gate: flight.gate,
+          terminal: flight.terminal,
+          bookingReference: flight.bookingReference,
+          ticketNumber: flight.ticketNumber,
+          price: flight.price,
+          currency: flight.currency,
+          taxes: flight.taxes,
+          fees: flight.fees,
+          category: flight.category,
+          tags: flight.tags,
+          companions: flight.companions,
+          receiptUrl: flight.receiptUrl,
+          actualDeparture: flight.actualDeparture,
+          actualArrival: flight.actualArrival,
+        };
+        await flightsApi.create(input);
+        const recentData = await flightsApi.getAll({
+          limit: API_LIMITS.RECENT_FLIGHTS,
+          offset: 0,
+        });
+        setRecentFlights(recentData.flights);
+        setTotalFlightsCount(recentData.total);
+        loadFlights();
+        addToast("success", "Flug dupliziert");
+      } catch (error) {
+        logger.error("Failed to duplicate flight:", error);
+        addToast("error", "Fehler beim Duplizieren");
+      }
+    },
+    [addToast, loadFlights]
+  );
 
   const handleFilterChange = (newFilters: FlightFilters) => {
     setFilters(newFilters);
@@ -611,8 +710,6 @@ export default function DashboardPage(): JSX.Element {
           >
             <MapContainer3D
               flights={geoFlights}
-              selectedFlightId={selectedFlightId}
-              onFlightClick={setSelectedFlightId}
               visMode={visMode}
               onVisModeChange={handleVisModeChange}
               minRouteCount={filters.minRouteCount ?? 1}
@@ -776,154 +873,16 @@ export default function DashboardPage(): JSX.Element {
         </div>
 
         {/* Left Overlay Panel: Flight List */}
-        <AnimatePresence>
-          {leftOpen && (
-            <>
-              <div className="fixed inset-0 bg-black/40 z-30" onClick={() => setLeftOpen(false)} />
-              <motion.div
-                initial={{ x: -380 }}
-                animate={{ x: 0 }}
-                exit={{ x: -380 }}
-                transition={{ type: "spring", stiffness: 300, damping: 30 }}
-                className="fixed left-0 top-14 bottom-0 w-80 z-40 flex flex-col overflow-hidden"
-                style={{
-                  background: "rgba(22,27,34,0.95)",
-                  backdropFilter: "blur(20px)",
-                  borderRight: "1px solid var(--color-border)",
-                }}
-              >
-                {/* Panel header */}
-                <div
-                  className="flex items-center justify-between px-4 py-3"
-                  style={{ borderBottom: "1px solid var(--color-border)" }}
-                >
-                  <span className="text-sm font-semibold" style={{ color: "var(--text-primary)" }}>
-                    {t("dashboard:recentFlights")}
-                    <span className="ml-2 text-xs font-mono" style={{ color: "var(--text-muted)" }}>
-                      ({totalFlightsCount})
-                    </span>
-                  </span>
-                  <button onClick={() => setLeftOpen(false)} style={{ color: "var(--text-muted)" }}>
-                    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path
-                        strokeLinecap="round"
-                        strokeLinejoin="round"
-                        strokeWidth={2}
-                        d="M6 18L18 6M6 6l12 12"
-                      />
-                    </svg>
-                  </button>
-                </div>
-
-                {/* Flight list */}
-                <div className="flex-1 overflow-y-auto">
-                  {loadingRecent ? (
-                    <div
-                      className="flex items-center justify-center h-20"
-                      style={{ color: "var(--text-muted)" }}
-                    >
-                      <svg className="w-5 h-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                        <circle
-                          className="opacity-25"
-                          cx="12"
-                          cy="12"
-                          r="10"
-                          stroke="currentColor"
-                          strokeWidth="4"
-                        />
-                        <path
-                          className="opacity-75"
-                          fill="currentColor"
-                          d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
-                        />
-                      </svg>
-                    </div>
-                  ) : recentFlights.length === 0 ? (
-                    <div className="p-6 text-center text-sm" style={{ color: "var(--text-muted)" }}>
-                      {t("dashboard:noFlights")}
-                    </div>
-                  ) : (
-                    <motion.ul
-                      initial="hidden"
-                      animate="visible"
-                      variants={{
-                        hidden: {},
-                        visible: { transition: { staggerChildren: 0.04 } },
-                      }}
-                    >
-                      {recentFlights.map((flight) => (
-                        <motion.li
-                          key={flight.id}
-                          variants={{
-                            hidden: { opacity: 0, x: -16 },
-                            visible: { opacity: 1, x: 0 },
-                          }}
-                        >
-                          <button
-                            onClick={() => {
-                              setSelectedFlightId(flight.id);
-                            }}
-                            className="w-full text-left px-4 py-3 transition-colors border-b"
-                            style={{
-                              borderColor: "var(--color-border)",
-                              background:
-                                selectedFlightId === flight.id
-                                  ? "var(--bg-elevated)"
-                                  : "transparent",
-                              borderLeft:
-                                selectedFlightId === flight.id
-                                  ? "3px solid var(--accent)"
-                                  : "3px solid transparent",
-                            }}
-                            onMouseEnter={(e) => {
-                              if (selectedFlightId !== flight.id)
-                                (e.currentTarget as HTMLButtonElement).style.background =
-                                  "var(--bg-elevated)";
-                            }}
-                            onMouseLeave={(e) => {
-                              if (selectedFlightId !== flight.id)
-                                (e.currentTarget as HTMLButtonElement).style.background =
-                                  "transparent";
-                            }}
-                          >
-                            <div className="flex items-center justify-between mb-0.5">
-                              <span
-                                className="font-mono text-sm font-semibold"
-                                style={{ color: "var(--text-primary)" }}
-                              >
-                                {flight.depIata || flight.depIcao || "?"} →{" "}
-                                {flight.arrIata || flight.arrIcao || "?"}
-                              </span>
-                              <span className="text-xs" style={{ color: "var(--text-muted)" }}>
-                                {flight.airline || ""}
-                              </span>
-                            </div>
-                            <div className="text-xs" style={{ color: "var(--text-muted)" }}>
-                              {flight.departureTime
-                                ? new Date(flight.departureTime).toLocaleDateString()
-                                : t("dashboard:unknownDate")}
-                              {flight.flightNumber && ` · ${flight.flightNumber}`}
-                            </div>
-                          </button>
-                        </motion.li>
-                      ))}
-                    </motion.ul>
-                  )}
-                </div>
-
-                {/* Quick actions at bottom */}
-                <div className="p-3" style={{ borderTop: "1px solid var(--color-border)" }}>
-                  <button
-                    onClick={() => setShowFlightForm(true)}
-                    className="btn-primary w-full text-sm"
-                  >
-                    + {t("dashboard:addFlight")}
-                  </button>
-                </div>
-              </motion.div>
-            </>
-          )}
-        </AnimatePresence>
+        <FlightPanel
+          flights={recentFlights}
+          totalCount={totalFlightsCount}
+          isOpen={leftOpen}
+          onClose={() => setLeftOpen(false)}
+          onEdit={(flight) => setEditingFlight(flight)}
+          onDuplicate={handleDuplicateFlight}
+          onDelete={handleDeleteFlight}
+          onAddFlight={() => setShowFlightForm(true)}
+        />
 
         {/* Right Overlay Panel: Stats */}
         <AnimatePresence>

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -298,7 +298,7 @@ export default function DashboardPage(): JSX.Element {
     (flightId: string) => {
       setRecentFlights((prev) => prev.filter((f) => f.id !== flightId));
       setTotalFlightsCount((prev) => prev - 1);
-      addToast("info", "Flug gelöscht");
+      addToast("info", t("dashboard:success.flightDeletedPending"));
 
       const timer = setTimeout(() => {
         pendingDeletes.current.delete(flightId);
@@ -314,7 +314,7 @@ export default function DashboardPage(): JSX.Element {
             setTotalFlightsCount(recentData.total);
           } catch (error) {
             logger.error("Failed to delete flight:", error);
-            addToast("error", "Fehler beim Löschen des Fluges");
+            addToast("error", t("dashboard:errors.deleteFlight"));
             const recentData = await flightsApi.getAll({
               limit: API_LIMITS.RECENT_FLIGHTS,
               offset: 0,
@@ -382,14 +382,21 @@ export default function DashboardPage(): JSX.Element {
         setRecentFlights(recentData.flights);
         setTotalFlightsCount(recentData.total);
         loadFlights();
-        addToast("success", "Flug dupliziert");
+        addToast("success", t("dashboard:success.flightDuplicated"));
       } catch (error) {
         logger.error("Failed to duplicate flight:", error);
-        addToast("error", "Fehler beim Duplizieren");
+        addToast("error", t("dashboard:errors.duplicateFlight"));
       }
     },
     [addToast, loadFlights]
   );
+
+  useEffect(() => {
+    const timers = pendingDeletes.current;
+    return () => {
+      timers.forEach((timer) => clearTimeout(timer));
+    };
+  }, []);
 
   const handleFilterChange = (newFilters: FlightFilters) => {
     setFilters(newFilters);

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -7,6 +7,7 @@ import { useToastStore } from "../store/toastStore";
 import { logger } from "../lib/logger";
 import { useTranslation } from "../hooks/useTranslation";
 import MapContainer3D from "../components/MapContainer3D";
+import { useFlightSelectionStore } from "../store/flightSelectionStore";
 import SimplifiedFlightFormV2 from "../components/SimplifiedFlightFormV2";
 import FlightEditModal from "../components/FlightEditModal";
 import Stats from "../components/Stats";
@@ -720,6 +721,11 @@ export default function DashboardPage(): JSX.Element {
               visMode={visMode}
               onVisModeChange={handleVisModeChange}
               minRouteCount={filters.minRouteCount ?? 1}
+              onFlightClick={(id) => {
+                const flight = recentFlights.find((f) => f.id === id);
+                if (flight) useFlightSelectionStore.getState().setSelection([flight]);
+              }}
+              onEdit={(flight) => setEditingFlight(flight)}
               filterSlot={
                 visMode !== "trips" ? <Filters onFilterChange={handleFilterChange} /> : undefined
               }

--- a/frontend/src/store/flightSelectionStore.ts
+++ b/frontend/src/store/flightSelectionStore.ts
@@ -1,0 +1,23 @@
+import { create } from "zustand";
+import type { Flight } from "../types";
+
+interface FlightSelectionState {
+  selectedIds: string[];
+  selectedFlights: Flight[];
+  highlightMode: "single" | "group" | null;
+  setSelection: (ids: string[], flights: Flight[]) => void;
+  clearSelection: () => void;
+}
+
+export const useFlightSelectionStore = create<FlightSelectionState>()((set) => ({
+  selectedIds: [],
+  selectedFlights: [],
+  highlightMode: null,
+  setSelection: (ids, flights) =>
+    set({
+      selectedIds: ids,
+      selectedFlights: flights,
+      highlightMode: ids.length === 0 ? null : ids.length === 1 ? "single" : "group",
+    }),
+  clearSelection: () => set({ selectedIds: [], selectedFlights: [], highlightMode: null }),
+}));

--- a/frontend/src/store/flightSelectionStore.ts
+++ b/frontend/src/store/flightSelectionStore.ts
@@ -5,7 +5,7 @@ interface FlightSelectionState {
   selectedIds: string[];
   selectedFlights: Flight[];
   highlightMode: "single" | "group" | null;
-  setSelection: (ids: string[], flights: Flight[]) => void;
+  setSelection: (flights: Flight[]) => void;
   clearSelection: () => void;
 }
 
@@ -13,11 +13,11 @@ export const useFlightSelectionStore = create<FlightSelectionState>()((set) => (
   selectedIds: [],
   selectedFlights: [],
   highlightMode: null,
-  setSelection: (ids, flights) =>
+  setSelection: (flights) =>
     set({
-      selectedIds: ids,
       selectedFlights: flights,
-      highlightMode: ids.length === 0 ? null : ids.length === 1 ? "single" : "group",
+      selectedIds: flights.map((f) => f.id),
+      highlightMode: flights.length === 0 ? null : flights.length === 1 ? "single" : "group",
     }),
   clearSelection: () => set({ selectedIds: [], selectedFlights: [], highlightMode: null }),
 }));

--- a/frontend/src/utils/groupFlights.ts
+++ b/frontend/src/utils/groupFlights.ts
@@ -7,15 +7,17 @@ export type FlightGroup =
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
 
 function buildLabel(flights: Flight[]): string {
-  const codes: string[] = [];
-  for (let i = 0; i < flights.length; i++) {
-    const f = flights[i];
-    if (i === 0) codes.push(f.depIata ?? f.depIcao ?? "?");
-    codes.push(f.arrIata ?? f.arrIcao ?? "?");
-  }
-  return codes.join(" → ");
+  const first = flights[0].depIata ?? flights[0].depIcao ?? "?";
+  const rest = flights.map((f) => f.arrIata ?? f.arrIcao ?? "?");
+  return [first, ...rest].join(" → ");
 }
 
+/**
+ * Returns true if flight B is a connecting leg for flight A.
+ * Assumes IATA and ICAO codes are populated with the same priority on both ends
+ * (e.g. both IATA-first or both ICAO-first). Mixed modes (arrIcao vs depIata for
+ * the same airport) will not match.
+ */
 function connects(a: Flight, b: Flight): boolean {
   const aArr = a.arrIata ?? a.arrIcao;
   const bDep = b.depIata ?? b.depIcao;
@@ -24,6 +26,18 @@ function connects(a: Flight, b: Flight): boolean {
   return gapMs >= 0 && gapMs <= TWELVE_HOURS_MS;
 }
 
+/**
+ * Groups connecting flights into multi-leg entries.
+ *
+ * Two consecutive flights (after sorting by departure time) are grouped when:
+ * - The arrival airport of flight A matches the departure airport of flight B
+ * - The gap between A's arrival and B's departure is between 0 and 12 hours
+ *
+ * **Limitation:** Only adjacent-after-sort flights can be chained. A connecting
+ * flight that sorts between two unrelated flights will not be matched to its
+ * true partner. In practice, connecting legs share the same booking and sort
+ * adjacently by departure time.
+ */
 export function groupFlights(flights: Flight[]): FlightGroup[] {
   const sorted = [...flights].sort(
     (a, b) => new Date(a.departureTime).getTime() - new Date(b.departureTime).getTime()

--- a/frontend/src/utils/groupFlights.ts
+++ b/frontend/src/utils/groupFlights.ts
@@ -1,0 +1,54 @@
+import type { Flight } from "../types";
+
+export type FlightGroup =
+  | { type: "single"; flight: Flight }
+  | { type: "multileg"; flights: Flight[]; label: string };
+
+const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000;
+
+function buildLabel(flights: Flight[]): string {
+  const codes: string[] = [];
+  for (let i = 0; i < flights.length; i++) {
+    const f = flights[i];
+    if (i === 0) codes.push(f.depIata ?? f.depIcao ?? "?");
+    codes.push(f.arrIata ?? f.arrIcao ?? "?");
+  }
+  return codes.join(" → ");
+}
+
+function connects(a: Flight, b: Flight): boolean {
+  const aArr = a.arrIata ?? a.arrIcao;
+  const bDep = b.depIata ?? b.depIcao;
+  if (!aArr || !bDep || aArr !== bDep) return false;
+  const gapMs = new Date(b.departureTime).getTime() - new Date(a.arrivalTime).getTime();
+  return gapMs >= 0 && gapMs <= TWELVE_HOURS_MS;
+}
+
+export function groupFlights(flights: Flight[]): FlightGroup[] {
+  const sorted = [...flights].sort(
+    (a, b) => new Date(a.departureTime).getTime() - new Date(b.departureTime).getTime()
+  );
+
+  const groups: FlightGroup[] = [];
+  let i = 0;
+
+  while (i < sorted.length) {
+    const chain: Flight[] = [sorted[i]];
+    while (i + 1 < sorted.length && connects(chain[chain.length - 1], sorted[i + 1])) {
+      i++;
+      chain.push(sorted[i]);
+    }
+    if (chain.length === 1) {
+      groups.push({ type: "single", flight: chain[0] });
+    } else {
+      groups.push({
+        type: "multileg",
+        flights: chain,
+        label: buildLabel(chain),
+      });
+    }
+    i++;
+  }
+
+  return groups;
+}

--- a/frontend/src/utils/mapAnimationHelpers.ts
+++ b/frontend/src/utils/mapAnimationHelpers.ts
@@ -1,0 +1,34 @@
+/**
+ * Compute [west, south, east, north] bounding box for a set of [lon, lat] points.
+ * Returns null if points array is empty.
+ */
+export function computeBbox(
+  points: Array<[number, number]>
+): [number, number, number, number] | null {
+  if (points.length === 0) return null;
+  let minLon = Infinity,
+    maxLon = -Infinity,
+    minLat = Infinity,
+    maxLat = -Infinity;
+  for (const [lon, lat] of points) {
+    if (lon < minLon) minLon = lon;
+    if (lon > maxLon) maxLon = lon;
+    if (lat < minLat) minLat = lat;
+    if (lat > maxLat) maxLat = lat;
+  }
+  return [minLon, minLat, maxLon, maxLat];
+}
+
+/** Linearly interpolate a position along the arc at progress t (0→1). */
+export function arcPosition(
+  source: [number, number],
+  target: [number, number],
+  t: number
+): [number, number] {
+  return [source[0] + (target[0] - source[0]) * t, source[1] + (target[1] - source[1]) * t];
+}
+
+/** Ease-in-out cubic for smooth animation */
+export function easeInOut(t: number): number {
+  return t < 0.5 ? 4 * t * t * t : 1 - Math.pow(-2 * t + 2, 3) / 2;
+}


### PR DESCRIPTION
## Summary

- **`useFlightSelectionStore`** — Zustand store syncing panel ↔ map selection; `setSelection(flights[])` derives IDs internally
- **`FlightPanel`** — animated slide-in panel (Framer Motion) with flight grouping for multi-leg connections; replaces 149-line inline JSX in DashboardPage
- **`FlightGroupItem` / `FlightEntry` / `QuickActions` / `InlineStats`** — composable panel sub-components with hover quick-actions and inline stats (distance, duration, seat class, CO₂, aircraft)
- **`MapTooltip`** — absolute-positioned overlay anchored to the route midpoint via `map.project()`, 50ms fade-in, edit/close actions
- **Map spotlight** — when a flight is selected: non-selected routes dim to 8% opacity, selected route gets full brightness + glow layer
- **flyTo animation** — map flies to the bounding box of the selected flight's dep/arr airports (600 ms)
- **Plane animation** — rAF-driven ✈ TextLayer arc-traversal (1500 ms/leg, easeInOut, 500 ms post-flyTo delay)
- **Airport pulse** — 3 ScatterplotLayer rings cycle opacity every 800 ms at dep/arr airports
- **CO₂ unit fix** — `co2Kg` stores kilograms; display was incorrectly showing tonnes

## Test plan

- [ ] Open flight panel, click a single flight → map flies to route, route highlighted, others dimmed
- [ ] ✈ marker animates along the arc, airport rings pulse
- [ ] MapTooltip appears ~1.8 s after selection with correct route/airline/distance/duration/CO₂
- [ ] "✏️ Bearbeiten" in tooltip opens edit modal; "✕" closes tooltip and clears selection
- [ ] Clicking map background clears selection → all routes return to normal opacity
- [ ] Multi-leg group renders correctly in panel (date + leg count label)
- [ ] Delete/duplicate actions in QuickActions work with optimistic UI (3 s undo window)
- [ ] CO₂ displays as `kg` (e.g. `450 kg`), not tonnes
- [ ] 187 frontend tests pass: `cd frontend && npx vitest --run`
- [ ] No TS errors: `cd frontend && npx tsc --noEmit`