### PR TITLE
fix(docker): re-add minimum Linux caps so quick-start stack boots on a clean host

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ is captured by the first-run setup wizard in the browser.
 
 ```bash
 # 1. Grab the compose file
-curl -O https://raw.githubusercontent.com/Abrechen2/TravStats/main/docker-compose.prod.yml
+curl -O https://raw.githubusercontent.com/Abrechen2/TravStats/Main/docker-compose.prod.yml
 
 # 2. Set one variable
 echo "DB_PASSWORD=$(openssl rand -base64 32)" > .env

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,7 @@ services:
       - SETUID
       - SETGID
       - FOWNER
+      - DAC_READ_SEARCH
     logging:
       driver: "json-file"
       options:
@@ -135,6 +136,10 @@ services:
       - ALL
     cap_add:
       - CHOWN
+      - DAC_OVERRIDE
+      - FOWNER
+      - SETUID
+      - SETGID
     logging:
       driver: "json-file"
       options:


### PR DESCRIPTION
## Summary

Fixes #85 — the README's "Option A — Stack" quick start currently fails on a clean Docker host because both `db` and `app` ship with `cap_drop: ALL` but don't re-add the capabilities their upstream entrypoints actually need to fix permissions on freshly created named volumes. As a result both containers restart-loop on first boot.

This PR adds the **minimum capability set** each entrypoint needs so the documented happy-path install works end-to-end, while preserving `cap_drop: ALL` and `no-new-privileges:true`. It also fixes the lowercase `main` typo in the same quick-start `curl` URL (the default branch is `Main`, so the existing URL 404s).

## Changes

### `docker-compose.prod.yml`

- **`db`**: add `DAC_READ_SEARCH`. The `postgres:15` entrypoint chowns `$PGDATA` to uid 999 (`postgres`) and then `find`s the now-postgres-owned directory as root for permission validation; without `DAC_READ_SEARCH` the traversal hits EACCES (`find: '/var/lib/postgresql/data': Permission denied`) and the container restart-loops. The actual writes happen post-`gosu` as the `postgres` user (which owns the files), so no root-side write bypass is needed — `DAC_READ_SEARCH` is narrower for this entrypoint than the broader, write-bypassing `DAC_OVERRIDE` originally suggested in #85, while still resolving the failure.
- **`app`**: add `DAC_OVERRIDE`, `FOWNER`, `SETUID`, `SETGID`. The TravStats entrypoint chowns `/app/data` to `node:node` mode 755 and then root needs to `mkdir`/write inside it (`DAC_OVERRIDE`), `chmod 700` the secrets dir it no longer owns (`FOWNER`), and supervisord drops to `user=node` for the backend / `www-data` for nginx workers (`SETUID`/`SETGID`). Currently it errors out with `/app/data/secrets is not writable` and the JWT secret can't be persisted.

### `README.md`

- Lowercase `main` → `Main` in the quick-start `curl` URL so it actually resolves.

## Verification

Reproduced the original failure on a vanilla Docker 29.4.1 host (`overlayfs`, no userns remap, rootful) following the README literally — both `db` and `app` restart-loop with the symptoms from #85.

With this patch, on freshly recreated named volumes:

- `travstats-db`, `travstats-app` and `travstats-ollama` all reach `healthy`
- `http://localhost:3000/setup` returns 200
- `/api/v1/health` returns 200

**`db` capability sufficiency was verified empirically** (since `DAC_READ_SEARCH` is narrower for this entrypoint than the broader, write-bypassing `DAC_OVERRIDE` originally suggested in #85):

| Test | Caps for `db` | Result |
|---|---|---|
| Negative control (current `main`) | `CHOWN`, `SETUID`, `SETGID`, `FOWNER` | restart-loops, `find: '/var/lib/postgresql/data': Permission denied` (matches #85 exactly) |
| This patch | + `DAC_READ_SEARCH` | `pg_isready` succeeds in ~2 s, no permission errors, `CREATE EXTENSION postgis` succeeds against a fresh DB |

So the cap added is necessary (negative control fails) and sufficient (positive case passes including the postgis init script `10_postgis.sh`).

## Scope notes

- No code, schema, or runtime behaviour changes — only the compose hardening profile and one URL char.
- `no-new-privileges:true` is preserved on both services; `cap_drop: ALL` is preserved.
- Did not touch `docs/release/*` or `docs/unraid/README.md` even though they contain the same lowercase `main` URL — those are historical release notes / forum copy and out of scope. (`docs/unraid/README.md` is also additionally broken — the file it points at no longer exists in this repo, so it needs a separate, larger fix.)
- No `CHANGELOG.md` edit — per `CLAUDE.md`, changelog entries are managed by the `/deploy` skill.

Closes #85.

