### PR TITLE
feat(trips): colour the timeline rail with trip progress (#184)

### DIFF
--- a/frontend/src/lib/__tests__/timelineRail.test.ts
+++ b/frontend/src/lib/__tests__/timelineRail.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { computeRailStates } from "../timelineRail";
+
+const NOW = new Date("2026-07-15T12:00:00Z").getTime();
+
+describe("computeRailStates", () => {
+  it("returns an empty array for no events", () => {
+    expect(computeRailStates([], NOW)).toEqual([]);
+  });
+
+  it("marks past dots and fills the rail up to the last past dot", () => {
+    const states = computeRailStates(
+      ["2026-07-10T08:00:00Z", "2026-07-14T08:00:00Z", "2026-07-20T08:00:00Z"],
+      NOW
+    );
+    expect(states.map((s) => s.dotPast)).toEqual([true, true, false]);
+    // Segment between two dots is filled only when the later event is past.
+    expect(states[1].topFilled).toBe(true);
+    expect(states[1].bottomFilled).toBe(false);
+    expect(states[2].topFilled).toBe(false);
+  });
+
+  it("keeps the whole rail neutral for a fully upcoming trip", () => {
+    const states = computeRailStates(["2026-08-01T08:00:00Z", "2026-08-05T08:00:00Z"], NOW);
+    expect(states.every((s) => !s.dotPast && !s.topFilled && !s.bottomFilled)).toBe(true);
+  });
+
+  it("fills the whole rail for a fully past trip", () => {
+    const states = computeRailStates(["2026-06-01T08:00:00Z", "2026-06-05T08:00:00Z"], NOW);
+    expect(states.every((s) => s.dotPast && s.topFilled)).toBe(true);
+    expect(states[0].bottomFilled).toBe(true);
+    // The last dot has no next event, so its bottom segment stays unfilled
+    // (it is not rendered for the last item anyway).
+    expect(states[1].bottomFilled).toBe(false);
+  });
+
+  it("treats an event exactly at now as past", () => {
+    const states = computeRailStates(["2026-07-15T12:00:00Z"], NOW);
+    expect(states[0].dotPast).toBe(true);
+  });
+
+  it("handles date-only strings (stops and journal entries)", () => {
+    const states = computeRailStates(["2026-07-14", "2026-07-16"], NOW);
+    expect(states.map((s) => s.dotPast)).toEqual([true, false]);
+  });
+});

--- a/frontend/src/lib/timelineRail.ts
+++ b/frontend/src/lib/timelineRail.ts
@@ -1,0 +1,31 @@
+/**
+ * Progress state for the trip-timeline rail (#184).
+ *
+ * The timeline marks past vs. upcoming activities on the left-hand rail —
+ * the connector line and its dots — instead of graying out whole entries.
+ * The rail "fills up" as the trip advances: every dot whose event has
+ * happened is coloured, and the line is filled exactly up to the last
+ * past dot.
+ */
+export interface RailState {
+  /** The event itself has happened (dot gets its domain colour). */
+  dotPast: boolean;
+  /** Segment from the previous dot down to this dot is filled. */
+  topFilled: boolean;
+  /** Segment from this dot down to the next dot is filled. */
+  bottomFilled: boolean;
+}
+
+/**
+ * Computes the rail state for a chronologically sorted list of event dates.
+ * A segment between two dots is filled only when the *later* event is past,
+ * so the coloured rail always ends at the last dot that has been reached.
+ */
+export function computeRailStates(dates: string[], nowMs: number): RailState[] {
+  const past = dates.map((d) => new Date(d).getTime() <= nowMs);
+  return past.map((dotPast, i) => ({
+    dotPast,
+    topFilled: dotPast,
+    bottomFilled: past[i + 1] ?? false,
+  }));
+}

--- a/frontend/src/pages/TripDetailPage.tsx
+++ b/frontend/src/pages/TripDetailPage.tsx
@@ -4,6 +4,7 @@ import { differenceInCalendarDays } from "date-fns";
 import { tripsApi } from "../lib/api";
 import { logger } from "../lib/logger";
 import { sumByCurrency } from "../lib/bookingCost";
+import { computeRailStates } from "../lib/timelineRail";
 import { useToastStore } from "../store/toastStore";
 import { useEnabledDomains } from "../hooks/useEnabledDomains";
 import { useTranslation } from "../hooks/useTranslation";
@@ -565,6 +566,15 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
     return out.sort((a, b) => new Date(a.date).getTime() - new Date(b.date).getTime());
   }, [trip]);
 
+  // Past/upcoming is shown on the rail (line + dots), not by graying out
+  // entries — see #184. Recomputed per render; a page-lifetime "now" is fine.
+  const railStates = useMemo(() => {
+    return computeRailStates(
+      events.map((ev) => ev.date),
+      Date.now()
+    );
+  }, [events]);
+
   const empty = events.length === 0;
 
   const handleDeleteJournal = async (entry: TripJournalEntry): Promise<void> => {
@@ -619,6 +629,7 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
           {events.map((ev, i) => {
             const isFirst = i === 0;
             const isLast = i === events.length - 1;
+            const rail = railStates[i];
             return (
               <li key={ev.id} className="relative" style={{ marginBottom: isLast ? 0 : 12 }}>
                 {/*
@@ -630,6 +641,8 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
                 {!isFirst && (
                   <span
                     aria-hidden
+                    data-testid="timeline-rail-top"
+                    data-filled={rail.topFilled}
                     className="absolute"
                     style={{
                       left: -18,
@@ -637,13 +650,15 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
                       bottom: "50%",
                       width: 2,
                       transform: "translateX(-50%)",
-                      background: "var(--color-border)",
+                      background: rail.topFilled ? "var(--accent)" : "var(--color-border)",
                     }}
                   />
                 )}
                 {!isLast && (
                   <span
                     aria-hidden
+                    data-testid="timeline-rail-bottom"
+                    data-filled={rail.bottomFilled}
                     className="absolute"
                     style={{
                       left: -18,
@@ -651,7 +666,7 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
                       bottom: -12,
                       width: 2,
                       transform: "translateX(-50%)",
-                      background: "var(--color-border)",
+                      background: rail.bottomFilled ? "var(--accent)" : "var(--color-border)",
                     }}
                   />
                 )}
@@ -659,16 +674,19 @@ function TimelineTab({ trip, onChanged, t }: TimelineTabProps): JSX.Element {
                 Dot: filled, vertically centered on the card (the li tightly
                 wraps its card, so top:50% is the card's centre) and horizontally
                 centered on the connector line. The base-coloured ring masks the
-                line where it passes behind the dot.
+                line where it passes behind the dot. Past events keep their
+                domain colour; upcoming ones stay neutral (#184).
               */}
                 <span
                   aria-hidden
+                  data-testid="timeline-rail-dot"
+                  data-past={rail.dotPast}
                   className="absolute w-3 h-3 rounded-full"
                   style={{
                     left: -18,
                     top: "50%",
                     transform: "translate(-50%, -50%)",
-                    background: dotColor(ev),
+                    background: rail.dotPast ? dotColor(ev) : "var(--color-border)",
                     boxShadow: "0 0 0 3px var(--bg-base)",
                   }}
                 />


### PR DESCRIPTION
Past vs. upcoming activities are now signalled on the left-hand rail
instead of by dimming entries: dots of events that have happened keep
their domain colour, upcoming dots turn neutral, and the connector line
fills with the accent colour exactly up to the last reached dot. Every
entry stays fully legible regardless of its state.

The fill rule lives in a pure helper (lib/timelineRail.ts) with unit
tests; a segment between two dots counts as filled only when the later
event is past.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_0147ipBsB2CmRWpA89ecEYBH