### PR TITLE
feat(parsing): a document announces itself, and a photograph is a document

### DIFF
--- a/backend/src/__tests__/routes/parseImage.test.ts
+++ b/backend/src/__tests__/routes/parseImage.test.ts
@@ -1,0 +1,295 @@
+import request from "supertest";
+import app from "../../index";
+import { prisma } from "../../db";
+import { hashPassword } from "../../utils/password";
+import { generateToken } from "../../utils/jwt";
+
+/**
+ * Route-level contract for POST /api/v1/parse-image (Forgejo #58).
+ *
+ * Everything expensive behind the route is mocked, for the same reason
+ * `parser.domain.test.ts` mocks the parsers: the flight and cruise paths dial a
+ * real Ollama instance and a 12b inference legitimately blows the 30s per-test
+ * cap, which turns the suite into a flaky gate blocker. OCR is worse still —
+ * Tesseract on a real photograph costs seconds of CPU and would make this suite
+ * a benchmark of the test machine rather than a check of the route.
+ *
+ * So the two ends are faked and the middle is real: OCR text goes in as a
+ * literal, the parsers answer instantly with an empty result, and the parts this
+ * file actually cares about — auth, image validation, the `auto` default, the
+ * classifier, the response envelope — all run for real.
+ *
+ * The image itself is NOT mocked. `validateBoardingPassImageBase64` sniffs magic
+ * numbers, and stubbing it out would leave the 400-before-OCR guard untested, so
+ * the fixtures below are a genuine 1x1 PNG and genuine non-image bytes.
+ */
+
+const mockRecognizeText = jest.fn<Promise<{ text: string; confidence: number }>, [string]>();
+
+jest.mock("../../services/parsers/vision/tesseractParser", () => ({
+  getTesseractParser: () => ({ recognizeText: mockRecognizeText }),
+}));
+
+jest.mock("../../services/bookingParser", () => ({
+  ...jest.requireActual("../../services/bookingParser"),
+  parseBookingText: jest.fn(async () => ({
+    flights: [],
+    parserUsed: "regex",
+    ollamaAvailable: false,
+  })),
+  parseBookingEmail: jest.fn(async () => ({
+    flights: [],
+    parserUsed: "regex",
+    ollamaAvailable: false,
+  })),
+}));
+
+jest.mock("../../services/cruiseBookingParser", () => ({
+  ...jest.requireActual("../../services/cruiseBookingParser"),
+  parseCruiseBookingText: jest.fn(async () => ({
+    cruises: [],
+    parserUsed: "ollama",
+    ollamaAvailable: false,
+  })),
+}));
+
+jest.mock("../../services/lodging/lodgingBookingParser", () => ({
+  ...jest.requireActual("../../services/lodging/lodgingBookingParser"),
+  parseLodgingBookingText: jest.fn(async () => ({
+    bookings: [],
+    parserUsed: "template",
+    ollamaAvailable: false,
+  })),
+}));
+
+import { parseBookingText } from "../../services/bookingParser";
+import { parseLodgingBookingText } from "../../services/lodging/lodgingBookingParser";
+
+const mockParseBookingText = parseBookingText as jest.MockedFunction<typeof parseBookingText>;
+const mockParseLodgingBookingText = parseLodgingBookingText as jest.MockedFunction<
+  typeof parseLodgingBookingText
+>;
+
+/**
+ * A real 1x1 PNG. The route's first act is magic-number validation, so a
+ * placeholder string would never reach OCR and every success case would be
+ * testing the 400 path by accident.
+ */
+const TINY_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==";
+
+/** Valid base64, but the decoded bytes are the ASCII text "not an image". */
+const NOT_AN_IMAGE_BASE64 = "bm90IGFuIGltYWdl";
+
+/**
+ * Hotel-shaped OCR text. Deliberately scores on the LODGING structural signals
+ * (check-in beside check-out, a night count, a room category) and on none of the
+ * flight ones — no flight number, no IATA pair — so a wrong classification here
+ * is a real regression and not a coin toss.
+ */
+const HOTEL_OCR_TEXT = [
+  "Buchungsbestaetigung Hotel Adlerhof",
+  "Check-in: 05.01.2026",
+  "Check-out: 07.01.2026",
+  "2 Naechte, Doppelzimmer, 2 Gaeste",
+  "Fruehstueck inklusive",
+].join("\n");
+
+/** A record-shaped response body, without reaching for `any`. */
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null) {
+    throw new Error(`Expected an object response body, received: ${typeof value}`);
+  }
+  return value as Record<string, unknown>;
+};
+
+describe("POST /api/v1/parse-image", () => {
+  let token: string;
+  let userId: string;
+
+  beforeAll(async () => {
+    const user = await prisma.user.create({
+      data: {
+        username: `parse-image-test-${Date.now()}`,
+        passwordHash: await hashPassword("password123"),
+        isAdmin: false,
+        isActive: true,
+      },
+    });
+    userId = user.id;
+    token = generateToken(userId);
+  });
+
+  afterAll(async () => {
+    await prisma.userSettings.deleteMany({ where: { userId } }).catch(() => {});
+    await prisma.user.delete({ where: { id: userId } }).catch(() => {});
+    await prisma.$disconnect();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRecognizeText.mockResolvedValue({ text: HOTEL_OCR_TEXT, confidence: 87.5 });
+  });
+
+  // -----------------------------------------------------------------------
+  // Access
+  // -----------------------------------------------------------------------
+
+  it("requires authentication", async () => {
+    // OCR is expensive and the parsers can reach an LLM, so this endpoint must
+    // never be usable without a session — same rule as every other parse route.
+    const res = await request(app).post("/api/v1/parse-image").send({
+      imageBase64: TINY_PNG_BASE64,
+    });
+
+    expect(res.status).toBe(401);
+    expect(mockRecognizeText).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // The default really is `auto`
+  // -----------------------------------------------------------------------
+
+  it("defaults to auto and classifies a hotel confirmation as lodging", async () => {
+    // This is the entire premise of the endpoint. The text routes default to
+    // `flight` for backwards compatibility; a photograph has no caller history
+    // to preserve, so this one defaults to `auto`. If that default ever slid
+    // back to `flight` the route would still answer 200 with an empty flight
+    // result, and nothing else in the suite would notice.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64 });
+
+    expect(res.status).toBe(200);
+    const body = asRecord(res.body);
+    expect(body.domain).toBe("lodging");
+    expect(mockParseLodgingBookingText).toHaveBeenCalledTimes(1);
+    expect(mockParseBookingText).not.toHaveBeenCalled();
+  });
+
+  it("marks a server-decided domain with domainSource=detected and the candidates", async () => {
+    // A client that sent `auto` must be able to tell a decision was made on its
+    // behalf, and must get the runners-up so it can offer a switch without a
+    // second round trip. Answering as if the caller had asked for lodging is
+    // exactly how the "send it three times" workaround survives.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64, domain: "auto" });
+
+    expect(res.status).toBe(200);
+    const body = asRecord(res.body);
+    expect(body.domainSource).toBe("detected");
+
+    const detection = asRecord(body.detection);
+    expect(detection.domain).toBe("lodging");
+    expect(Array.isArray(detection.candidates)).toBe(true);
+    expect((detection.candidates as unknown[]).length).toBeGreaterThan(1);
+    expect(typeof detection.confidence).toBe("number");
+  });
+
+  // -----------------------------------------------------------------------
+  // Explicit domains keep the old envelope
+  // -----------------------------------------------------------------------
+
+  it("routes an explicit domain=flight to the flight parser without consulting the classifier", async () => {
+    // The OCR text is hotel-shaped on purpose: if the classifier had a say, this
+    // would come back as lodging. The caller named a domain, so it must not.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64, domain: "flight" });
+
+    expect(res.status).toBe(200);
+    const body = asRecord(res.body);
+    expect(body.domain).toBe("flight");
+    expect(mockParseBookingText).toHaveBeenCalledTimes(1);
+    expect(mockParseLodgingBookingText).not.toHaveBeenCalled();
+  });
+
+  it("omits domainSource and detection entirely when the caller named the domain", async () => {
+    // The backwards-compatibility contract: a caller that already knows what it
+    // sent gets byte-identical body keys to the pre-`auto` routes. Reporting a
+    // "detection" for a decision the server never made would be a lie, and a
+    // client keying off the presence of the field would mis-read it.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64, domain: "flight" });
+
+    expect(res.status).toBe(200);
+    expect(res.body).not.toHaveProperty("domainSource");
+    expect(res.body).not.toHaveProperty("detection");
+  });
+
+  // -----------------------------------------------------------------------
+  // OCR reporting
+  // -----------------------------------------------------------------------
+
+  it("reports ocrConfidence and ocrTextLength on a successful parse", async () => {
+    // Reported, never used as a gate — a client shows it beside a thin result to
+    // explain why. It only helps if it is actually there, so pin it.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64 });
+
+    expect(res.status).toBe(200);
+    const body = asRecord(res.body);
+    expect(body.ocrConfidence).toBe(87.5);
+    expect(body.ocrTextLength).toBe(HOTEL_OCR_TEXT.length);
+  });
+
+  it("answers 422 with the confidence when OCR read too little text to parse", async () => {
+    // A photograph of a wall comes back as a handful of stray glyphs. Handing
+    // those to a parser burns an LLM round trip and produces an empty 200 that
+    // reads as "we could not understand your document" when the truth is "there
+    // was nothing on it". The confidence travels with the refusal so the client
+    // can say which of the two it was.
+    mockRecognizeText.mockResolvedValue({ text: "AB\n  cd ", confidence: 12.5 });
+
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: TINY_PNG_BASE64 });
+
+    expect(res.status).toBe(422);
+    const body = asRecord(res.body);
+    expect(body.error).toBe("No readable text");
+    expect(body.ocrConfidence).toBe(12.5);
+    expect(mockParseLodgingBookingText).not.toHaveBeenCalled();
+    expect(mockParseBookingText).not.toHaveBeenCalled();
+  });
+
+  // -----------------------------------------------------------------------
+  // Guards in front of the expensive work
+  // -----------------------------------------------------------------------
+
+  it("rejects a non-image payload with 400 before spending any OCR", async () => {
+    // Skipping OCR is the whole point of this guard — running Tesseract over
+    // arbitrary uploaded bytes is the cost it exists to avoid, so asserting the
+    // status alone would miss a regression that validated and then OCR'd anyway.
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ imageBase64: NOT_AN_IMAGE_BASE64 });
+
+    expect(res.status).toBe(400);
+    const body = asRecord(res.body);
+    expect(body.error).toBe("Validation failed");
+    expect(String(body.message)).toContain("Image validation failed");
+    expect(mockRecognizeText).not.toHaveBeenCalled();
+  });
+
+  it("rejects a body without imageBase64 at the schema layer", async () => {
+    const res = await request(app)
+      .post("/api/v1/parse-image")
+      .set("Cookie", [`auth_token=${token}`])
+      .send({ domain: "lodging" });
+
+    expect(res.status).toBe(400);
+    expect(asRecord(res.body).error).toBe("Validation failed");
+    expect(mockRecognizeText).not.toHaveBeenCalled();
+  });
+});

--- a/backend/src/middleware/rateLimit.ts
+++ b/backend/src/middleware/rateLimit.ts
@@ -242,8 +242,15 @@ export const backupRestoreLimiter = rateLimit({
 });
 
 /**
- * Rate limiter for boarding pass parsing (expensive LLM/vision operation)
- * Allows 20 parses per 15 minutes per IP
+ * Rate limiter for OCR routes — boarding passes and whole documents.
+ *
+ * 20 parses per 15 minutes per USER, not per IP. It was per IP until
+ * 2026-09-01, alone among the limiters in this file, which every sibling keys
+ * with `userOrIpKey`. On a self-hosted instance behind a reverse proxy or
+ * Cloudflare that made one shared budget for everybody: a single user
+ * photographing a stack of receipts locked the others out of the most
+ * expensive endpoint in the app. Nothing here suggests that was a decision, and
+ * `/parse-image` made it matter for hotel and cruise users too.
  */
 export const boardingPassParseLimiter = rateLimit({
   windowMs: RATE_LIMITS.BOARDING_PASS_PARSE_WINDOW_MS,
@@ -251,6 +258,7 @@ export const boardingPassParseLimiter = rateLimit({
   message: 'Too many boarding pass parse requests, please try again later',
   standardHeaders: true,
   legacyHeaders: false,
+  keyGenerator: userOrIpKey,
 });
 
 /**

--- a/backend/src/routes/emailParse.ts
+++ b/backend/src/routes/emailParse.ts
@@ -1,11 +1,7 @@
 import { Router, Response } from 'express';
 import { authenticate, AuthRequest } from '../middleware/auth';
 import { emailParseLimiter } from '../middleware/rateLimit';
-import { parseBookingEmail } from '../services/bookingParser';
-import { parseCruiseBookingText } from '../services/cruiseBookingParser';
-import { resolveCruiseEntities, hydrateResolvedCruises } from '../services/cruiseEntityResolver';
-import { parseLodgingBookingText } from '../services/lodging/lodgingBookingParser';
-import { bookingsToCandidates } from '../services/lodging/lodgingCandidates';
+import { parseDocument, REQUESTABLE_DOMAINS } from '../services/parsing/parseDocument';
 import { extractEmailFromFile } from '../services/emailExtractor';
 import { uploadEmailFile, getEmailUploadDir } from '../middleware/upload';
 import { z } from 'zod';
@@ -14,7 +10,6 @@ import fs from 'fs';
 import path from 'path';
 import { validateEmailFile } from '../utils/fileValidation';
 import { describeParserError } from '../utils/parserErrors';
-import { PARSER_SUPPORTED_DOMAINS } from '../shared/domains';
 
 const router = Router();
 
@@ -27,7 +22,9 @@ const parseEmailSchema = z.object({
     (val) => !val || val.length <= 1000,
     { message: 'Subject too long (max 1000 characters)' }
   ),
-  domain: z.enum(PARSER_SUPPORTED_DOMAINS).optional().default('flight'),
+  // 'auto' asks the server to decide what the document is — see Forgejo #57.
+  // The default stays 'flight' so no existing caller changes behaviour.
+  domain: z.enum(REQUESTABLE_DOMAINS).optional().default('flight'),
 });
 
 /**
@@ -37,11 +34,12 @@ const parseEmailSchema = z.object({
  * Body:
  * - emailContent: string (required) - Email body text or HTML
  * - subject: string (optional) - Email subject line
+ * - domain: 'flight' | 'cruise' | 'lodging' | 'auto' (default 'flight')
  *
- * Returns:
- * - flights: ParsedBooking[] - Array of extracted flight information
- * - parserUsed: 'ollama' | 'regex' - Which parser was used
- * - ollamaAvailable: boolean - Whether Ollama was available
+ * Returns the domain-shaped body plus `text` and `subject`. When `domain: 'auto'`
+ * was asked for, the answer additionally carries `domainSource: 'detected'` and a
+ * `detection` block naming the runners-up, so a client that disagrees can re-ask
+ * explicitly instead of sending the mail three times.
  */
 router.post('/parse-email', authenticate, emailParseLimiter, async (req: AuthRequest, res: Response) => {
   try {
@@ -53,53 +51,42 @@ router.post('/parse-email', authenticate, emailParseLimiter, async (req: AuthReq
 
     logger.info({ userId, domain: parsed.domain }, '[Email Parse] Parsing email');
 
-    if (parsed.domain === 'cruise') {
-      const combined = subject ? `${subject}\n\n${emailContent}` : emailContent;
-      const cruiseResult = await parseCruiseBookingText(combined);
-      const resolved = await Promise.all(cruiseResult.cruises.map(resolveCruiseEntities));
-      const cruises = await hydrateResolvedCruises(resolved, userId);
-      return res.json({
-        cruises,
-        parserUsed: cruiseResult.parserUsed,
-        ollamaAvailable: cruiseResult.ollamaAvailable,
-        text: emailContent,
-        subject: subject ?? undefined,
-        domain: 'cruise',
-      });
-    }
+    const outcome = await parseDocument({
+      text: emailContent,
+      // An empty subject is no subject: it must not become a blank first line
+      // in the text the parsers score, and the flight parser treats the two
+      // differently. This mirrors the `subject || undefined` the flight branch
+      // used to do here.
+      subject: subject || undefined,
+      domain: parsed.domain,
+      // Never 'document' on this route: the email entry point reads the subject
+      // and the HTML part, and a header is what dates a mail whose body carries
+      // a year-less date (#285).
+      source: 'email',
+      userId,
+    });
 
-    if (parsed.domain === 'lodging') {
-      const combined = subject ? `${subject}\n\n${emailContent}` : emailContent;
-      const lodgingResult = await parseLodgingBookingText(combined);
-      logger.info(
-        { userId, parserUsed: lodgingResult.parserUsed, bookingCount: lodgingResult.bookings.length },
-        '[Email Parse] Lodging parsing complete',
-      );
-      return res.json({
-        domain: 'lodging',
-        candidates: bookingsToCandidates(lodgingResult.bookings),
-        parserUsed: lodgingResult.parserUsed,
-        ollamaAvailable: lodgingResult.ollamaAvailable,
-        fallbackReason: lodgingResult.fallbackReason,
-        text: emailContent,
-        subject: subject ?? undefined,
-      });
-    }
+    const body = outcome.body;
 
-    const result = await parseBookingEmail(
-      subject || undefined,
-      emailContent,
-      undefined,
-      userId ? { userId } : undefined
+    logger.info(
+      { userId, domain: outcome.domain, domainSource: outcome.domainSource },
+      '[Email Parse] Parsing complete',
     );
 
-    logger.info(`[Email Parse] Parsing complete: ${result.flights.length} flight(s) found using ${result.parserUsed}`);
-
     res.json({
-      ...result,
+      ...body,
       text: emailContent,
       subject: subject ?? undefined,
-      airlineNotice: result.flights[0]?.airlineNotice ?? null,
+      // Only a flight carries one — a cruise or hotel confirmation has no
+      // airline to say anything about.
+      ...(body.domain === 'flight'
+        ? { airlineNotice: body.flights[0]?.airlineNotice ?? null }
+        : {}),
+      // Present only when the server decided, so an explicit request keeps
+      // exactly the response shape it had before.
+      ...(outcome.domainSource === 'detected'
+        ? { domainSource: outcome.domainSource, detection: outcome.detection }
+        : {}),
     });
   } catch (error) {
     if (error instanceof z.ZodError) {
@@ -125,11 +112,11 @@ router.post('/parse-email', authenticate, emailParseLimiter, async (req: AuthReq
  *
  * Body: multipart/form-data
  * - email: File (required) - Email file (.msg, .eml, or .txt)
+ * - domain: 'flight' | 'cruise' | 'lodging' | 'auto' (default 'flight')
  *
- * Returns:
- * - flights: ParsedBooking[] - Array of extracted flight information
- * - parserUsed: 'ollama' | 'regex' | 'openai' | 'claude' - Which parser was used
- * - subject: string - Extracted email subject
+ * Returns the domain-shaped body plus `subject`, `text` and `html`. As on
+ * /parse-email, `domainSource` and `detection` appear only when the server
+ * decided the domain itself.
  */
 router.post(
   '/parse-email-file',
@@ -150,7 +137,7 @@ router.post(
       // Domain discriminator (optional, defaults to 'flight').
       // Multipart form-data: rawDomain comes as string from form field.
       const rawDomain = typeof req.body?.domain === 'string' ? req.body.domain : 'flight';
-      const domainSchema = z.enum(PARSER_SUPPORTED_DOMAINS).optional().default('flight');
+      const domainSchema = z.enum(REQUESTABLE_DOMAINS).optional().default('flight');
       const domainParse = domainSchema.safeParse(rawDomain);
       if (!domainParse.success) {
         if (filePath && fs.existsSync(filePath)) {
@@ -211,82 +198,45 @@ router.post(
         domain: domainValue,
       }, '[Email Parse File] Email extracted from file');
 
-      if (domainValue === 'cruise') {
-        const combined = extracted.subject
-          ? `${extracted.subject}\n\n${extracted.text}`
-          : extracted.text;
-        const cruiseResult = await parseCruiseBookingText(combined);
-        const resolved = await Promise.all(cruiseResult.cruises.map(resolveCruiseEntities));
-        const cruises = await hydrateResolvedCruises(resolved, userId);
+      const outcome = await parseDocument({
+        text: extracted.text,
+        subject: extracted.subject,
+        html: extracted.html,
+        domain: domainValue,
+        // See /parse-email above: the flight path must take the email entry
+        // point so subject and HTML are read (#285).
+        source: 'email',
+        userId,
+      });
 
-        if (filePath && fs.existsSync(filePath)) {
-          fs.unlinkSync(filePath);
-          logger.debug({ filePath }, '[Email Parse File] Temporary file deleted');
-        }
-
-        return res.json({
-          cruises,
-          parserUsed: cruiseResult.parserUsed,
-          ollamaAvailable: cruiseResult.ollamaAvailable,
-          subject: extracted.subject,
-          text: extracted.text,
-          html: extracted.html ?? undefined,
-          domain: 'cruise',
-        });
-      }
-
-      if (domainValue === 'lodging') {
-        const combined = extracted.subject
-          ? `${extracted.subject}\n\n${extracted.text}`
-          : extracted.text;
-        const lodgingResult = await parseLodgingBookingText(combined);
-
-        if (filePath && fs.existsSync(filePath)) {
-          fs.unlinkSync(filePath);
-          logger.debug({ filePath }, '[Email Parse File] Temporary file deleted');
-        }
-
-        logger.info(
-          { userId, parserUsed: lodgingResult.parserUsed, bookingCount: lodgingResult.bookings.length },
-          '[Email Parse File] Lodging parsing complete',
-        );
-
-        return res.json({
-          domain: 'lodging',
-          candidates: bookingsToCandidates(lodgingResult.bookings),
-          parserUsed: lodgingResult.parserUsed,
-          ollamaAvailable: lodgingResult.ollamaAvailable,
-          fallbackReason: lodgingResult.fallbackReason,
-          subject: extracted.subject,
-          text: extracted.text,
-          html: extracted.html ?? undefined,
-        });
-      }
-
-      // Parse email with configured parser
-      const result = await parseBookingEmail(
-        extracted.subject,
-        extracted.text,
-        extracted.html,
-        userId ? { userId } : undefined
-      );
+      const body = outcome.body;
 
       logger.info(
-        `[Email Parse File] Parsing complete: ${result.flights.length} flight(s) found using ${result.parserUsed}`
+        { userId, domain: outcome.domain, domainSource: outcome.domainSource },
+        '[Email Parse File] Parsing complete',
       );
 
-      // Cleanup: Delete temporary file
+      // Cleanup: Delete temporary file. Before the response, so the upload is
+      // gone by the time the caller is told the parse succeeded — the catch
+      // block below covers every failing path.
       if (filePath && fs.existsSync(filePath)) {
         fs.unlinkSync(filePath);
         logger.debug({ filePath }, '[Email Parse File] Temporary file deleted');
       }
 
       res.json({
-        ...result,
+        ...body,
         subject: extracted.subject,
         text: extracted.text,
         html: extracted.html ?? undefined,
-        airlineNotice: result.flights[0]?.airlineNotice ?? null,
+        // Flight-only, for the same reason as on /parse-email.
+        ...(body.domain === 'flight'
+          ? { airlineNotice: body.flights[0]?.airlineNotice ?? null }
+          : {}),
+        // Present only when the server decided the domain.
+        ...(outcome.domainSource === 'detected'
+          ? { domainSource: outcome.domainSource, detection: outcome.detection }
+          : {}),
       });
     } catch (error) {
       // Cleanup: Delete temporary file on error

--- a/backend/src/routes/imageParse.ts
+++ b/backend/src/routes/imageParse.ts
@@ -1,0 +1,161 @@
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { authenticate, AuthRequest } from '../middleware/auth';
+import { boardingPassParseLimiter } from '../middleware/rateLimit';
+import { validateBoardingPassImageBase64 } from '../utils/fileValidation';
+import { getTesseractParser } from '../services/parsers/vision/tesseractParser';
+import { parseDocument, REQUESTABLE_DOMAINS } from '../services/parsing/parseDocument';
+import { describeParserError } from '../utils/parserErrors';
+import { FILE_LIMITS } from '../config/constants';
+import logger from '../utils/logger';
+
+const router = Router();
+
+/**
+ * The shortest OCR result that could plausibly be a booking confirmation.
+ *
+ * A blank page, a photograph of a wall or a failed scan all come back as a
+ * handful of stray glyphs. Handing those to a parser wastes an LLM round trip
+ * and answers with an empty result that looks like "we could not read your
+ * document" when the truth is "there was nothing on it". Below this, the route
+ * says so instead.
+ */
+const MIN_USABLE_TEXT_LENGTH = 40;
+
+/**
+ * The base64 length that corresponds to the real, decoded byte cap.
+ *
+ * Base64 inflates by 4/3. The boarding-pass route caps the STRING at 20 MB
+ * while `validateBoardingPassImageBase64` caps decoded bytes at 10 MB, so its
+ * schema check can never fire — the two disagree and the smaller one always
+ * wins. Deriving the string cap from the byte cap keeps them in step, and makes
+ * the cheap check the one that runs first: an oversized payload is refused
+ * before it is decoded into memory.
+ */
+const MAX_IMAGE_BASE64_LENGTH = Math.ceil((FILE_LIMITS.BOARDING_PASS_MAX_SIZE * 4) / 3) + 4;
+
+const parseImageSchema = z.object({
+  imageBase64: z
+    .string()
+    .min(1, 'Image data is required')
+    .max(MAX_IMAGE_BASE64_LENGTH, 'Image too large'),
+  domain: z.enum(REQUESTABLE_DOMAINS).optional().default('auto'),
+});
+
+/**
+ * POST /api/v1/parse-image — read any travel document from a photograph.
+ *
+ * Forgejo #58. Until now an image could only ever become a flight: the boarding
+ * pass scanner is flight-only by construction, `/parse-boardingpass` answers 501
+ * for anything else, and `/parse-pdf` — which does handle all three domains —
+ * needs text and refuses a scan. So the loop closed with nothing in it, and the
+ * single most photographed travel document there is, a hotel bill, was the one
+ * thing the product could not capture from a photograph.
+ *
+ * The fix is not a new parser. Text parsing already handles lodging and cruise
+ * well; the gap was purely the step in front of them, pixels to text. This route
+ * is that step and nothing more: OCR, then the same dispatcher `/parse-pdf` and
+ * `/parse-email` use, so a photograph, a PDF and a pasted mail are three doors
+ * into one behaviour.
+ *
+ * `domain` defaults to `'auto'` here, unlike the text routes which default to
+ * `'flight'` for backwards compatibility. A photograph has no caller history to
+ * preserve, and "I do not know what this is" is the honest default for one —
+ * that is the whole premise of Forgejo #57.
+ */
+router.post(
+  '/parse-image',
+  authenticate,
+  // Deliberately the SAME bucket as the boarding-pass scanner rather than a
+  // second one of its own: both spend a Tesseract worker per request, and what
+  // needs limiting is OCR work per user, not per URL. Two independent buckets
+  // would let one user do twice the OCR by alternating routes.
+  boardingPassParseLimiter,
+  async (req: AuthRequest, res: Response) => {
+    try {
+      const parsed = parseImageSchema.parse(req.body);
+      const userId = req.userId;
+
+      // The same validation the boarding pass scanner applies: magic-number
+      // sniffing, a declared-versus-detected MIME cross-check, and a real
+      // decoded-byte cap. Reusing it rather than restating it keeps one answer
+      // to "is this an image we accept".
+      const validation = validateBoardingPassImageBase64(parsed.imageBase64);
+      if (!validation.valid) {
+        logger.warn(
+          { userId, reason: validation.reason },
+          '[Image Parse] Image validation failed',
+        );
+        return res.status(400).json({
+          error: 'Validation failed',
+          message: `Image validation failed: ${validation.reason}`,
+        });
+      }
+
+      const { text, confidence } = await getTesseractParser().recognizeText(parsed.imageBase64);
+      // One measure of "how much was read", used for BOTH the gate below and
+      // the number reported back. They were the trimmed and untrimmed lengths
+      // respectively, so a mostly-blank scan reported a figure far above the
+      // one it had actually been judged on.
+      const readableLength = text.trim().length;
+
+      if (readableLength < MIN_USABLE_TEXT_LENGTH) {
+        logger.info(
+          { userId, textLength: readableLength, confidence },
+          '[Image Parse] Too little text to parse',
+        );
+        return res.status(422).json({
+          error: 'No readable text',
+          message:
+            'Almost no text could be read from this image. A sharper, straighter photograph of the whole page usually helps.',
+          ocrConfidence: confidence,
+        });
+      }
+
+      logger.info(
+        { userId, chars: text.length, confidence, domain: parsed.domain },
+        '[Image Parse] OCR complete, parsing...',
+      );
+
+      const outcome = await parseDocument({
+        text,
+        domain: parsed.domain,
+        source: 'document',
+        userId,
+      });
+
+      logger.info(
+        { userId, domain: outcome.domain, domainSource: outcome.domainSource },
+        '[Image Parse] Parsing complete',
+      );
+
+      res.json({
+        ...outcome.body,
+        /**
+         * Reported, never used as a gate. OCR confidence says how sure the
+         * engine is about the GLYPHS, which is a different question from
+         * whether the document parsed — a crisp photograph of the wrong page
+         * scores high. A client may show it beside a thin result to explain
+         * why; branching on it here would reject readable documents.
+         */
+        ocrConfidence: confidence,
+        ocrTextLength: readableLength,
+        ...(outcome.domainSource === 'detected'
+          ? { domainSource: outcome.domainSource, detection: outcome.detection }
+          : {}),
+      });
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        return res.status(400).json({ error: 'Validation failed', details: error.errors });
+      }
+      logger.error({ error }, '[Image Parse] Parsing failed');
+      const described = describeParserError(error);
+      res.status(described.status).json({
+        error: 'Image parsing failed',
+        message: described.message,
+      });
+    }
+  },
+);
+
+export default router;

--- a/backend/src/routes/mounts.ts
+++ b/backend/src/routes/mounts.ts
@@ -34,6 +34,7 @@ import emailParseRoutes from './emailParse';
 import boardingpassParseRoutes from './boardingpassParse';
 import boardingpassMatchRoutes from './boardingpassMatch';
 import pdfParseRoutes from './pdfParse';
+import imageParseRoutes from './imageParse';
 import diagnosticExportRoutes from './diagnosticExport';
 import diagnosticsRoutes from './diagnostics';
 import setupRoutes from './setup';
@@ -113,6 +114,7 @@ export const apiMounts: ApiMount[] = [
   { id: 'boardingpassParse', base: '/api/v1', router: boardingpassParseRoutes },
   { id: 'boardingpassMatch', base: '/api/v1/boardingpass', router: boardingpassMatchRoutes },
   { id: 'pdfParse', base: '/api/v1', router: pdfParseRoutes },
+  { id: 'imageParse', base: '/api/v1', router: imageParseRoutes },
   { id: 'diagnosticExport', base: '/api/v1', router: diagnosticExportRoutes },
   { id: 'diagnostics', base: '/api/v1', router: diagnosticsRoutes },
   { id: 'parserTemplates', base: '/api/v1/parser-templates', router: parserTemplatesRoutes },

--- a/backend/src/routes/pdfParse.ts
+++ b/backend/src/routes/pdfParse.ts
@@ -4,13 +4,8 @@ import { pdfParseLimiter } from '../middleware/rateLimit';
 import { z } from 'zod';
 import logger from '../utils/logger';
 import { extractTextFromPdf, isBcbpText } from '../services/pdfParser';
-import { parseBookingText } from '../services/bookingParser';
-import { parseCruiseBookingText } from '../services/cruiseBookingParser';
-import { resolveCruiseEntities, hydrateResolvedCruises } from '../services/cruiseEntityResolver';
-import { parseLodgingBookingText } from '../services/lodging/lodgingBookingParser';
-import { bookingsToCandidates } from '../services/lodging/lodgingCandidates';
+import { parseDocument, REQUESTABLE_DOMAINS } from '../services/parsing/parseDocument';
 import { FILE_LIMITS } from '../config/constants';
-import { PARSER_SUPPORTED_DOMAINS } from '../shared/domains';
 import { describeParserError } from '../utils/parserErrors';
 
 const router = Router();
@@ -20,29 +15,30 @@ const parsePdfSchema = z.object({
     .string()
     .min(1, 'PDF data is required')
     .max(FILE_LIMITS.PDF_MAX_SIZE * 2, 'PDF too large'), // base64 overhead ~1.37x, use 2x for safety
-  domain: z.enum(PARSER_SUPPORTED_DOMAINS).optional().default('flight'),
+  // 'auto' asks the server to decide what the document is — see Forgejo #57.
+  // The default stays 'flight' so no existing caller changes behaviour.
+  domain: z.enum(REQUESTABLE_DOMAINS).optional().default('flight'),
 });
 
 /**
  * POST /api/v1/parse-pdf
- * Parse a PDF file (booking confirmation or boarding pass) and extract flight data.
+ * Parse a PDF booking confirmation or boarding pass.
  *
  * Body:
  * - pdfBase64: string (required) — Base64-encoded PDF file content
+ * - domain: 'flight' | 'cruise' | 'lodging' | 'auto' (default 'flight')
  *
- * Returns:
- * - flights: ParsedBooking[]
- * - provider: string
- * - pdfTextLength: number
- * - bcbpDetected: boolean
+ * Returns the domain-shaped body plus `pdfTextLength`. When `domain: 'auto'`
+ * was asked for, the answer additionally carries `domainSource: 'detected'` and
+ * a `detection` block naming the runners-up, so a client that disagrees can
+ * re-ask explicitly instead of sending the document three times.
  */
 router.post('/parse-pdf', authenticate, pdfParseLimiter, async (req: AuthRequest, res: Response) => {
   try {
     const parsed = parsePdfSchema.parse(req.body);
-    const { pdfBase64 } = parsed;
     const userId = req.userId;
 
-    const buffer = Buffer.from(pdfBase64, 'base64');
+    const buffer = Buffer.from(parsed.pdfBase64, 'base64');
 
     let pdfText: string;
     try {
@@ -59,7 +55,7 @@ router.post('/parse-pdf', authenticate, pdfParseLimiter, async (req: AuthRequest
       return res.status(422).json({
         error: 'Empty PDF',
         message:
-          'No text could be extracted from this PDF. It may be a scanned image — use the Boarding Pass Scanner instead.',
+          'No text could be extracted from this PDF. It may be a scanned image — send the page to /parse-image, which reads any travel document, or use the Boarding Pass Scanner.',
       });
     }
 
@@ -68,42 +64,30 @@ router.post('/parse-pdf', authenticate, pdfParseLimiter, async (req: AuthRequest
       '[PDF Parse] Text extracted, parsing...',
     );
 
-    if (parsed.domain === 'cruise') {
-      const cruiseResult = await parseCruiseBookingText(pdfText);
-      const resolved = await Promise.all(cruiseResult.cruises.map(resolveCruiseEntities));
-      const cruises = await hydrateResolvedCruises(resolved, userId);
-      return res.json({
-        cruises,
-        parserUsed: cruiseResult.parserUsed,
-        ollamaAvailable: cruiseResult.ollamaAvailable,
-        pdfTextLength: pdfText.length,
-        domain: 'cruise',
-      });
-    }
+    const outcome = await parseDocument({
+      text: pdfText,
+      domain: parsed.domain,
+      source: 'document',
+      userId,
+    });
 
-    if (parsed.domain === 'lodging') {
-      const lodgingResult = await parseLodgingBookingText(pdfText);
-      logger.info(
-        { userId, parserUsed: lodgingResult.parserUsed, bookingCount: lodgingResult.bookings.length },
-        '[PDF Parse] Lodging parsing complete',
-      );
-      return res.json({
-        domain: 'lodging',
-        candidates: bookingsToCandidates(lodgingResult.bookings),
-        parserUsed: lodgingResult.parserUsed,
-        ollamaAvailable: lodgingResult.ollamaAvailable,
-        fallbackReason: lodgingResult.fallbackReason,
-        pdfTextLength: pdfText.length,
-      });
-    }
-
-    const bcbpDetected = isBcbpText(pdfText);
-    const result = await parseBookingText(pdfText, userId);
+    logger.info(
+      { userId, domain: outcome.domain, domainSource: outcome.domainSource },
+      '[PDF Parse] Parsing complete',
+    );
 
     res.json({
-      ...result,
+      ...outcome.body,
+      // Only for a flight: it describes a barcode, and a cruise or hotel
+      // confirmation never carries one. Reporting `false` on those would
+      // suggest the question had been asked of them.
+      ...(outcome.domain === 'flight' ? { bcbpDetected: isBcbpText(pdfText) } : {}),
       pdfTextLength: pdfText.length,
-      bcbpDetected,
+      // Present only when the server decided, so an explicit request keeps
+      // exactly the response shape it had before.
+      ...(outcome.domainSource === 'detected'
+        ? { domainSource: outcome.domainSource, detection: outcome.detection }
+        : {}),
     });
   } catch (error) {
     if (error instanceof z.ZodError) {

--- a/backend/src/services/openapi/paths/parsing.ts
+++ b/backend/src/services/openapi/paths/parsing.ts
@@ -24,6 +24,36 @@ const parsedFlightSchema = registry.register(
     .openapi("ParsedFlight")
 );
 
+/**
+ * The evidence behind an automatic domain decision. Shared by every route that
+ * accepts `domain: "auto"`, because a client should learn to read it once.
+ */
+const domainDetectionSchema = registry.register(
+  "DomainDetection",
+  z
+    .object({
+      domain: z.enum(["flight", "cruise", "lodging"]),
+      confidence: z.number().min(0).max(1),
+      candidates: z.array(
+        z.object({
+          domain: z.enum(["flight", "cruise", "lodging"]),
+          score: z.number(),
+          confidence: z.number(),
+          matched: z.array(z.string()).describe("Signal ids that fired, e.g. \"checkin-checkout\""),
+        })
+      ),
+    })
+    .openapi("DomainDetection")
+);
+
+const requestableDomain = z
+  .enum(["flight", "cruise", "lodging", "auto"])
+  .describe(
+    "'auto' lets the server decide what the document is and report the evidence. " +
+      "Text routes default to 'flight' for backwards compatibility; /parse-image " +
+      "defaults to 'auto', because a photograph has no caller history to preserve."
+  );
+
 registry.registerPath({
   method: "post",
   path: "/parse-email",
@@ -44,6 +74,7 @@ registry.registerPath({
             .object({
               emailContent: z.string().min(1).max(10 * 1024 * 1024),
               subject: z.string().max(1000).optional(),
+              domain: requestableDomain.default("flight").optional(),
             })
             .openapi("ParseEmailRequest"),
         },
@@ -65,6 +96,60 @@ registry.registerPath({
     },
     400: { description: "Validation failed", content: errorContent },
     429: { description: "Rate-limited (parser is expensive)", content: errorContent },
+  },
+});
+
+registry.registerPath({
+  method: "post",
+  path: "/parse-image",
+  summary: "Read any travel document from a photograph",
+  description:
+    "OCRs a photographed booking confirmation and parses it as a flight, a " +
+    "cruise or a hotel stay. Until this existed an image could only ever become " +
+    "a flight: the boarding-pass routes are flight-only, and /parse-pdf handles " +
+    "all three domains but needs text and refuses a scan — so a photographed " +
+    "hotel bill had no way in. This is only the missing step in front of the " +
+    "existing parsers, pixels to text; the parsing itself is the same dispatcher " +
+    "/parse-pdf and /parse-email use. " +
+    "Accepts JPEG, PNG, GIF or WebP up to 10 MB decoded. `ocrConfidence` is " +
+    "reported but never used as a gate — it describes the glyphs, not whether " +
+    "the document parsed. The result is NOT auto-saved.",
+  tags: ["Parsers"],
+  request: {
+    body: {
+      content: {
+        "application/json": {
+          schema: z
+            .object({
+              imageBase64: z.string().min(1).max(20 * 1024 * 1024),
+              domain: requestableDomain.default("auto").optional(),
+            })
+            .openapi("ParseImageRequest"),
+        },
+      },
+    },
+  },
+  responses: {
+    200: {
+      description: "The domain-shaped parse result, plus OCR metadata",
+      content: {
+        "application/json": {
+          schema: z.object({
+            domain: z.enum(["flight", "cruise", "lodging"]),
+            ocrConfidence: z.number(),
+            ocrTextLength: z.number(),
+            domainSource: z
+              .enum(["requested", "detected"])
+              .optional()
+              .describe("Present only when the server decided the domain"),
+            detection: domainDetectionSchema.optional(),
+          }),
+        },
+      },
+    },
+    400: { description: "Validation failed or unsupported image", content: errorContent },
+    422: { description: "Almost no text could be read from the image", content: errorContent },
+    429: { description: "Rate-limited (OCR is expensive)", content: errorContent },
   },
 });
 

--- a/backend/src/services/parsers/vision/tesseractParser.ts
+++ b/backend/src/services/parsers/vision/tesseractParser.ts
@@ -39,6 +39,66 @@ export class TesseractVisionParser implements IVisionParser {
   }
 
   /**
+   * A SECOND worker, for reading whole travel documents rather than boarding
+   * passes — Forgejo #58.
+   *
+   * Deliberately separate from the one above, which stays exactly as it was.
+   * The difference is the language set: a boarding pass is alphanumeric and
+   * English, while the documents this one reads are hotel bills and sailing
+   * confirmations, and the corpus this product is built against is German.
+   * Reading "Nächte" with English-only training data loses the umlaut, and the
+   * lodging parser matches on that word.
+   *
+   * Why not simply widen the existing worker: the extra language pack is
+   * fetched at first use, and an air-gapped instance would then fail to create
+   * ANY worker — taking boarding-pass scanning down with it, a feature that
+   * works today. Two workers cost memory only once both are actually used, and
+   * this one degrades to English on its own rather than failing.
+   */
+  private docWorker: Worker | null = null;
+
+  private async ensureDocumentWorker(): Promise<Worker> {
+    if (this.docWorker) return this.docWorker;
+
+    try {
+      this.docWorker = await createWorker(['eng', 'deu'], 1);
+      logger.info('[Tesseract Parser] Document OCR worker initialized (eng+deu)');
+    } catch (error) {
+      // The German pack could not be fetched — offline, or no cache. English
+      // still reads Latin script, so a degraded answer beats no answer; it is
+      // logged at warn so the cause is visible when a German document parses
+      // badly, rather than looking like a parser bug.
+      logger.warn(
+        { error },
+        '[Tesseract Parser] German language pack unavailable, falling back to English only'
+      );
+      this.docWorker = await createWorker('eng', 1);
+    }
+
+    return this.docWorker;
+  }
+
+  /**
+   * OCR an image and return the TEXT, without interpreting it as a flight.
+   *
+   * `parseImage` below answers "which flight is this", which is the wrong
+   * question for a hotel invoice. This answers "what does it say", and the
+   * caller hands the text to whichever domain parser applies — which is what
+   * lets one image route serve all three domains.
+   */
+  async recognizeText(imageBase64: string): Promise<{ text: string; confidence: number }> {
+    const worker = await this.ensureDocumentWorker();
+    const { data } = await worker.recognize(Buffer.from(imageBase64, 'base64'));
+
+    logger.info(
+      { confidence: data.confidence, textLength: data.text.length },
+      '[Tesseract Parser] Document OCR complete'
+    );
+
+    return { text: data.text, confidence: data.confidence };
+  }
+
+  /**
    * Cleanup worker on shutdown
    */
   async cleanup(): Promise<void> {
@@ -47,6 +107,11 @@ export class TesseractVisionParser implements IVisionParser {
       this.worker = null;
       this.isInitialized = false;
       logger.info('[Tesseract Parser] OCR worker terminated');
+    }
+    if (this.docWorker) {
+      await this.docWorker.terminate();
+      this.docWorker = null;
+      logger.info('[Tesseract Parser] Document OCR worker terminated');
     }
   }
 

--- a/backend/src/services/parsing/__tests__/documentDomain.test.ts
+++ b/backend/src/services/parsing/__tests__/documentDomain.test.ts
@@ -1,0 +1,407 @@
+/**
+ * Pins the three rules the classifier's header claims for itself, not just the
+ * happy path. Each of the three came out of a shipped bug, so the tests that
+ * matter here are the adversarial ones: a flight mail that also sells a hotel,
+ * a newsletter that quotes a price, and a document with one thin clue.
+ *
+ * A happy-path test would pass against a classifier that simply counts the word
+ * "Hotel" — which is exactly the classifier we must not have.
+ */
+
+import { scoreDocument, type DomainScore } from "../documentDomain";
+import { PARSER_SUPPORTED_DOMAINS, type ParserSupportedDomain } from "../../../shared/domains";
+
+/**
+ * Reads one domain out of the candidate list. Written as a lookup with an
+ * explicit throw rather than a non-null assertion so a missing domain fails
+ * with a sentence instead of a TypeError three lines later.
+ */
+const candidate = (
+  candidates: readonly DomainScore[],
+  domain: ParserSupportedDomain
+): DomainScore => {
+  const found = candidates.find((entry) => entry.domain === domain);
+  if (found === undefined) {
+    throw new Error(`No candidate for domain "${domain}" — candidates are incomplete`);
+  }
+  return found;
+};
+
+// --- Fixtures ---------------------------------------------------------------
+// Multi-line and shaped like the real thing. A one-line fixture cannot show
+// whether the STRUCTURE was recognised or just a noun, and structure is the
+// whole point of the weighting.
+
+const DE_FLIGHT = `Lufthansa – Ihre Buchungsbestätigung
+
+Buchungscode: X7K2QP
+Flug LH 401 am 14. März 2026
+Strecke: FRA – JFK
+Frankfurt am Main, Terminal 1, Gate B24
+Abflug 10:25 Uhr, Boarding ab 09:45 Uhr
+Freigepäck: 1 Gepäckstück bis 23 kg
+Online-Check-in ab 24 Stunden vor Abflug möglich`;
+
+const DE_LODGING = `Booking.com – Ihre Buchung ist bestätigt
+
+Hotel Alpenblick, Garmisch-Partenkirchen
+Anreise: Freitag, 12. Juni 2026 ab 15:00 Uhr
+Abreise: Montag, 15. Juni 2026 bis 11:00 Uhr
+3 Nächte, 2 Gäste
+Zimmerkategorie: Doppelzimmer mit Balkon
+Frühstück inklusive`;
+
+const DE_CRUISE = `AIDA Cruises – Ihre Reiseunterlagen
+
+Kreuzfahrt "Kanaren im Winter"
+Einschiffung: 07. Februar 2026, Hafen Las Palmas
+Ausschiffung: 14. Februar 2026
+Kabine 8215, Deck 8 (Balkonkabine)
+Seetag am 09. Februar
+Bordguthaben: 100 EUR pro Person`;
+
+/** The adversarial one: a real flight document whose footer sells a hotel. */
+const DE_FLIGHT_WITH_HOTEL_OFFER = `Lufthansa – Ihre Buchungsbestätigung
+
+Buchungscode: X7K2QP
+Flug LH 401 am 14. März 2026
+Strecke: FRA – JFK
+Terminal 1, Gate B24, Boarding ab 09:45 Uhr
+Freigepäck: 1 Gepäckstück bis 23 kg
+
+Passend zu Ihrem Flug: Hotel in Manhattan ab 129 EUR pro Nacht dazubuchen.`;
+
+/**
+ * Content-free marketing mail. Carries the literal price from forgejo#35 twice:
+ * once lowercase as it was reported, once shouted in a headline, because the
+ * uppercase form is the one that actually looks like the Air Berlin flight
+ * number AB380 and therefore the one the guard has to survive.
+ */
+const DE_MARKETING = `SOMMER-SPECIAL 2026
+
+Jetzt buchen und sparen: Städtetrips ab 380 EUR pro Person!
+AB 380 EUR nach Mallorca, ab 149 EUR nach Rom.
+Flug und Hotel bequem zusammen buchen.
+
+Newsletter abbestellen? Klicken Sie hier.`;
+
+const EN_FLIGHT = `British Airways — Booking confirmation
+
+Booking reference: QT4L9Z
+Flight BA 286 on 3 May 2026
+LHR – SFO
+Departure 11:40, Terminal 5, Gate A12
+Boarding time 11:05
+Checked baggage: 1 x 23 kg
+Online check-in opens 24 hours before departure`;
+
+const EN_LODGING = `Booking.com — Your reservation is confirmed
+
+The Riverside Inn, Bath
+Check-in: Friday, 12 June 2026 from 15:00
+Check-out: Monday, 15 June 2026 until 11:00
+3 nights, 2 adults
+Room type: Double room, breakfast included`;
+
+const EN_CRUISE = `Royal Caribbean — Cruise ticket booklet
+
+Ship: Anthem of the Seas
+Embarkation: 7 February 2026, Southampton
+Cabin 8215, Deck 8 — balcony stateroom
+Day at sea on 9 February
+Port of call: Vigo`;
+
+describe("scoreDocument — realistic confirmations", () => {
+  it("reads a German airline confirmation as a flight, on structure not on nouns", () => {
+    const result = scoreDocument(DE_FLIGHT);
+
+    expect(result.domain).toBe("flight");
+    expect(result.confidence).toBe(1);
+    // The two weight-5 signals are what make this a flight; if only the word
+    // "Flug" had matched, the answer would be right for the wrong reason.
+    const flight = candidate(result.candidates, "flight");
+    expect(flight.matched).toEqual(expect.arrayContaining(["flight-number", "iata-route"]));
+    expect(candidate(result.candidates, "lodging").score).toBe(0);
+    expect(candidate(result.candidates, "cruise").score).toBe(0);
+  });
+
+  it("reads a German Booking.com confirmation as lodging", () => {
+    const result = scoreDocument(DE_LODGING);
+
+    expect(result.domain).toBe("lodging");
+    expect(result.confidence).toBe(1);
+    const lodging = candidate(result.candidates, "lodging");
+    // Anreise/Abreise as a pair and a night count — the lodging shape.
+    expect(lodging.matched).toEqual(expect.arrayContaining(["checkin-checkout", "nights"]));
+    expect(candidate(result.candidates, "flight").score).toBe(0);
+  });
+
+  it("reads a German cruise confirmation as a cruise", () => {
+    const result = scoreDocument(DE_CRUISE);
+
+    expect(result.domain).toBe("cruise");
+    expect(result.confidence).toBe(1);
+    const cruise = candidate(result.candidates, "cruise");
+    expect(cruise.matched).toEqual(
+      expect.arrayContaining(["cabin-deck", "sea-day", "embarkation"])
+    );
+    expect(candidate(result.candidates, "lodging").score).toBe(0);
+  });
+});
+
+describe("scoreDocument — rule 2: a bare noun is weak, a structure is strong", () => {
+  it("keeps a flight confirmation that also offers a hotel on flight", () => {
+    // This is the case the weights exist for. Half of all airline mail sells a
+    // hotel in its footer; if the bare noun could outvote a flight number, every
+    // such mail would be filed as a stay.
+    const result = scoreDocument(DE_FLIGHT_WITH_HOTEL_OFFER);
+
+    expect(result.domain).toBe("flight");
+    expect(result.confidence).toBeGreaterThan(0.8);
+
+    const lodging = candidate(result.candidates, "lodging");
+    // The hotel offer IS seen — it just isn't evidence of a stay. Only the
+    // weight-1 noun fires; no check-in/check-out pair, no night count.
+    expect(lodging.matched).toEqual(["hotel-noun"]);
+    expect(lodging.score).toBe(1);
+    expect(candidate(result.candidates, "flight").score).toBeGreaterThan(lodging.score * 10);
+  });
+
+  it("does not let the word Hotel alone outrank a single flight structure", () => {
+    // Deliberately lopsided in the noun's favour: three lodging nouns against
+    // one flight number. Weight, not count, has to decide.
+    const result = scoreDocument("Hotel, Pension oder Hostel gefällig? Ihr Flug LH 401 wartet.");
+
+    expect(result.domain).toBe("flight");
+  });
+});
+
+describe("scoreDocument — rule 1: a signal counts once, however often it repeats", () => {
+  it("scores one occurrence and twenty occurrences identically", () => {
+    // Otherwise the longest document wins, and marketing mail is the longest
+    // thing anybody forwards (forgejo#17).
+    const once = scoreDocument("Boarding");
+    const many = scoreDocument(Array.from({ length: 20 }, () => "Boarding").join("\n"));
+
+    const flightOnce = candidate(once.candidates, "flight");
+    const flightMany = candidate(many.candidates, "flight");
+
+    expect(flightMany.score).toBe(flightOnce.score);
+    expect(flightMany.matched).toEqual(flightOnce.matched);
+    expect(many.confidence).toBe(once.confidence);
+  });
+
+  it("does not let a repeated weak noun beat a single strong structure", () => {
+    // The direct consequence of rule 1: shouting "Hotel" thirty times must not
+    // add up to a check-in/check-out pair.
+    const shouted = Array.from({ length: 30 }, () => "Hotel").join(" ");
+    const result = scoreDocument(`${shouted}\nFlug LH 401, Strecke FRA – JFK`);
+
+    expect(result.domain).toBe("flight");
+    expect(candidate(result.candidates, "lodging").score).toBe(1);
+  });
+});
+
+describe("scoreDocument — forgejo#35: a price is not a flight number", () => {
+  it("does not fire the flight-number signal on 'ab 380 EUR'", () => {
+    const result = scoreDocument(DE_MARKETING);
+
+    const flight = candidate(result.candidates, "flight");
+    expect(flight.matched).not.toContain("flight-number");
+    expect(flight.matched).not.toContain("iata-route");
+  });
+
+  it("leaves content-free marketing mail at a confidence nobody would act on", () => {
+    const result = scoreDocument(DE_MARKETING);
+
+    // The nouns "Flug" and "Hotel" each fire once, so the mail is not silent —
+    // but two weight-1 nouns are not a booking, and the number has to say so.
+    expect(result.confidence).toBeLessThan(0.15);
+    expect(candidate(result.candidates, "flight").score).toBe(1);
+    expect(candidate(result.candidates, "lodging").score).toBe(1);
+  });
+
+  it("still recognises a genuine flight number that is not followed by a currency", () => {
+    // The guard has to be narrow: AB 380 really is an Air Berlin flight number.
+    // Suppressing every "AB 380" would trade one bug for the opposite one.
+    const result = scoreDocument("Ihr Flug AB 380 nach Mallorca startet pünktlich.");
+
+    expect(candidate(result.candidates, "flight").matched).toContain("flight-number");
+    expect(result.domain).toBe("flight");
+  });
+});
+
+describe("scoreDocument — rule 3: thin evidence stays uncertain even when unanimous", () => {
+  it("reports a lone weak match as low confidence, not as certainty", () => {
+    // Exactly one weight-1 signal, for exactly one domain, contradicted by
+    // nothing. Its SHARE of the evidence is 100%; its worth is not.
+    const result = scoreDocument("Das Hotel war wirklich schön.");
+
+    expect(result.domain).toBe("lodging");
+    const lodging = candidate(result.candidates, "lodging");
+    expect(lodging.matched).toEqual(["hotel-noun"]);
+    expect(lodging.score).toBe(1);
+    expect(result.confidence).toBeGreaterThan(0);
+    expect(result.confidence).toBeLessThan(0.5);
+    expect(result.confidence).toBe(0.1); // share 1.0 × damping 1/10
+  });
+
+  it("applies the damping formula share × min(1, score / 10), rounded to 2 places", () => {
+    // "Boarding" (flight, weight 3) beside "Hotel" (lodging, weight 1).
+    // flight:  3/4 × 3/10 = 0.225 → 0.22
+    // lodging: 1/4 × 1/10 = 0.025 → 0.03
+    //
+    // The two look inconsistent and are: 0.225 is not representable in binary
+    // and evaluates to 0.22499999999999998, so it rounds down, while 0.025
+    // lands just above and rounds up. Pinned as measured rather than as the
+    // decimal arithmetic suggests — a confidence is a hint for a UI, so a
+    // hundredth either way is not worth a rounding helper of our own, but a
+    // silent change of the formula is worth catching.
+    const result = scoreDocument("Boarding im Hotel");
+
+    expect(candidate(result.candidates, "flight").confidence).toBeCloseTo(0.22, 5);
+    expect(candidate(result.candidates, "lodging").confidence).toBeCloseTo(0.03, 5);
+  });
+
+  it("stops damping once the evidence is substantial", () => {
+    // Above the substantial threshold the confidence is pure share, so an
+    // uncontested well-evidenced document reaches a clean 1.
+    const result = scoreDocument(DE_CRUISE);
+
+    expect(candidate(result.candidates, "cruise").score).toBeGreaterThan(10);
+    expect(result.confidence).toBe(1);
+  });
+});
+
+describe("scoreDocument — it never refuses", () => {
+  const nothingToGoOn: readonly string[] = [
+    "",
+    "   \n\t  \r\n ",
+    "lorem ipsum dolor sit amet 1234 #### zzz qqq",
+  ];
+
+  it.each(nothingToGoOn)("returns the fallback domain instead of throwing for %j", (text) => {
+    // The caller asked for `auto` and must get an answer it can act on — the
+    // alternative is the "send the document three times" behaviour this exists
+    // to remove. Falling back to the first supported domain keeps the historical
+    // default (flight) rather than inventing a null the callers cannot handle.
+    expect(() => scoreDocument(text)).not.toThrow();
+
+    const result = scoreDocument(text);
+    expect(result.domain).toBe(PARSER_SUPPORTED_DOMAINS[0]);
+    expect(result.domain).not.toBeNull();
+    expect(result.confidence).toBe(0);
+    expect(result.candidates.every((entry) => entry.score === 0)).toBe(true);
+    expect(result.candidates.every((entry) => entry.matched.length === 0)).toBe(true);
+  });
+
+  it("keeps the headline and the candidate list agreeing when two domains tie", () => {
+    // Regression, found by this suite: the candidate list used to tie-break
+    // alphabetically while the headline tie-broke on PARSER_SUPPORTED_DOMAINS
+    // order. "Boarding" (flight, 3) against "an Bord" (cruise, 3) is a genuine
+    // tie, and every evidence-free document is one too — so the client was shown
+    // `domain: flight` beside a switch list that opened with `cruise`.
+    const result = scoreDocument("Boarding an Bord");
+
+    expect(candidate(result.candidates, "flight").score).toBe(
+      candidate(result.candidates, "cruise").score
+    );
+    expect(result.candidates[0].domain).toBe(result.domain);
+    expect(result.domain).toBe("flight");
+  });
+
+  it("breaks a tie towards the first supported domain rather than picking at random", () => {
+    // One weight-1 noun each. The evidence did not decide, so the historical
+    // default does — deterministically, so a retry gives the same answer.
+    const result = scoreDocument("Flug und Hotel");
+
+    expect(candidate(result.candidates, "flight").score).toBe(
+      candidate(result.candidates, "lodging").score
+    );
+    expect(result.domain).toBe(PARSER_SUPPORTED_DOMAINS[0]);
+  });
+});
+
+describe("scoreDocument — the candidate list is a usable offer to switch", () => {
+  const documents: ReadonlyArray<readonly [string, string]> = [
+    ["German flight", DE_FLIGHT],
+    ["German lodging", DE_LODGING],
+    ["German cruise", DE_CRUISE],
+    ["marketing", DE_MARKETING],
+    ["empty", ""],
+  ];
+
+  it.each(documents)("%s: lists every supported domain exactly once", (_label, text) => {
+    const result = scoreDocument(text);
+
+    expect(result.candidates).toHaveLength(PARSER_SUPPORTED_DOMAINS.length);
+    expect(new Set(result.candidates.map((entry) => entry.domain))).toEqual(
+      new Set(PARSER_SUPPORTED_DOMAINS)
+    );
+  });
+
+  it.each(documents)("%s: sorts candidates best first", (_label, text) => {
+    const scores = scoreDocument(text).candidates.map((entry) => entry.score);
+
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+  });
+
+  it.each(documents)("%s: the headline answer agrees with candidates[0]", (_label, text) => {
+    // The client renders the headline and the runners-up from the same object.
+    // If those two ever disagree it offers a switch to the domain it already
+    // chose, which reads as a bug to the user even though both fields are
+    // internally consistent.
+    const result = scoreDocument(text);
+    const best = result.candidates[0];
+
+    expect(result.domain).toBe(best.domain);
+    expect(result.confidence).toBe(best.confidence);
+  });
+});
+
+describe("scoreDocument — English documents, not only German", () => {
+  it("reads an English airline confirmation as a flight", () => {
+    const result = scoreDocument(EN_FLIGHT);
+
+    expect(result.domain).toBe("flight");
+    expect(result.confidence).toBe(1);
+    expect(candidate(result.candidates, "flight").matched).toEqual(
+      expect.arrayContaining(["flight-number", "iata-route", "pnr"])
+    );
+    // "Booking reference: QT4L9Z" must not be read as a flight number, and
+    // "check-in ... before departure" must not be read as a check-in/check-out
+    // pair — both are the kind of near-miss that only shows up in real copy.
+    expect(candidate(result.candidates, "lodging").score).toBe(0);
+  });
+
+  it("reads an English hotel confirmation as lodging", () => {
+    const result = scoreDocument(EN_LODGING);
+
+    expect(result.domain).toBe("lodging");
+    expect(candidate(result.candidates, "lodging").matched).toEqual(
+      expect.arrayContaining(["checkin-checkout", "nights", "room-category"])
+    );
+    expect(candidate(result.candidates, "flight").score).toBe(0);
+  });
+
+  it("reads an English cruise booklet as a cruise", () => {
+    const result = scoreDocument(EN_CRUISE);
+
+    expect(result.domain).toBe("cruise");
+    expect(candidate(result.candidates, "cruise").matched).toEqual(
+      expect.arrayContaining(["cabin-deck", "sea-day", "embarkation"])
+    );
+  });
+});
+
+describe("scoreDocument — the scan is bounded", () => {
+  it("ignores evidence past the 20k scan limit", () => {
+    // The cost must depend on the document, not on the size of the mail thread
+    // somebody forwarded it in. The trade is explicit: a confirmation quoted at
+    // the bottom of a very long thread is not seen.
+    const padding = "x".repeat(20_000);
+
+    expect(scoreDocument(`Boarding Gate B24 ${padding}`).confidence).toBeGreaterThan(0);
+    expect(scoreDocument(`${padding} Boarding Gate B24`).confidence).toBe(0);
+  });
+});

--- a/backend/src/services/parsing/documentDomain.ts
+++ b/backend/src/services/parsing/documentDomain.ts
@@ -1,0 +1,256 @@
+/**
+ * What kind of travel document is this? — Forgejo #57.
+ *
+ * Every parse route takes a `domain` and dispatches on it, which means the
+ * caller has to have decided already. That is the one decision a caller cannot
+ * make: whether a photographed confirmation is a hotel, a sailing or a flight
+ * is a property of the DOCUMENT, not of the tap that sent it. Without this,
+ * a client either asks the user in front of an empty screen, guesses, or sends
+ * the same document three times and keeps whichever answer parsed.
+ *
+ * ## Why a scorer and not the LLM
+ *
+ * The LLM path is optional and frequently absent: it exists only when an admin
+ * has configured `ollamaUrl` and `ollamaModel` (`services/parserSettings.ts`),
+ * and on the preview hardware it was measured at 0.3 tokens/second, so every
+ * parse ran into its timeout. A classifier that only works where Ollama works
+ * is not a classifier. This is cheap, synchronous, dependency-free and
+ * explainable: it returns the signals it matched, so a wrong answer can be
+ * argued with rather than merely retried.
+ *
+ * (The `USE_LLM_PARSER` env var named in older notes is dead — no TypeScript
+ * file reads it. Measured 2026-09-01; the only occurrence is a preview compose
+ * file. Do not gate anything on it.)
+ *
+ * ## Three rules the scoring follows, each learned from a real bug
+ *
+ * 1. A SIGNAL COUNTS ONCE, however often it appears. Otherwise the longest
+ *    document wins, and marketing mail is the longest thing anybody forwards.
+ *    This is the same failure mode as #17 and #35 — a newsletter mentioning
+ *    "ab 380 EUR" became flight AB380 — where repetition, not evidence, was
+ *    doing the deciding.
+ * 2. A BARE NOUN IS WEAK, A STRUCTURE IS STRONG. The word "Hotel" appears in
+ *    half of all airline mail; a check-in date beside a check-out date does
+ *    not. Weights encode that difference, so a flight confirmation offering a
+ *    hotel does not become a hotel.
+ * 3. THIN EVIDENCE MEANS LOW CONFIDENCE, EVEN WHEN IT IS UNANIMOUS. One weak
+ *    match that nothing contradicts is not proof. The confidence formula damps
+ *    for that explicitly rather than reporting a clean 1.0 for a single hit.
+ *
+ * ## What it deliberately does not do
+ *
+ * It never refuses. A caller asking for `auto` gets the leading domain even
+ * when confidence is low, together with the runners-up — because the issue's
+ * own ask is that a weak answer still returns what it parsed, so the client can
+ * offer to switch without a second round trip. Refusing would force exactly the
+ * "send it three times" behaviour this exists to remove.
+ */
+
+import { PARSER_SUPPORTED_DOMAINS, type ParserSupportedDomain } from "../../shared/domains";
+
+/** One piece of evidence: a pattern, what it is worth, and a name for it. */
+interface Signal {
+  readonly id: string;
+  readonly pattern: RegExp;
+  readonly weight: number;
+}
+
+/**
+ * Weights are on one scale across all three domains, so they can be compared:
+ *
+ *   5  structural — a shape only this kind of document has
+ *   3  strong     — a term the other domains do not use
+ *   2  supporting — typical, but imaginable elsewhere
+ *   1  weak       — a bare noun; never decisive on its own
+ *
+ * German first and English beside it, because the sample corpus this was built
+ * against is German and the product's primary locale is too.
+ */
+const SIGNALS: Record<ParserSupportedDomain, readonly Signal[]> = {
+  flight: [
+    // A flight number next to a route is the shape nothing else has. The
+    // boundary and the airline-prefix rule matter: "ab 380 EUR" must not match,
+    // which is the bug #35 was filed for.
+    { id: "flight-number", pattern: /\b[A-Z]{2}\s?\d{2,4}\b(?!\s*(EUR|USD|GBP|€|\$))/, weight: 5 },
+    {
+      id: "iata-route",
+      pattern: /\b[A-Z]{3}\s*(?:-|–|—|→|>|\bnach\b|\bto\b)\s*[A-Z]{3}\b/,
+      weight: 5,
+    },
+    { id: "boarding", pattern: /\b(boarding|einsteigen|boardingzeit|boarding time)\b/i, weight: 3 },
+    { id: "gate-terminal", pattern: /\b(gate|terminal)\s*[:\s]?\s*[A-Z]?\d{1,3}\b/i, weight: 3 },
+    { id: "pnr", pattern: /\b(buchungscode|booking reference|record locator|pnr)\b/i, weight: 3 },
+    {
+      id: "baggage",
+      pattern: /\b(freigep(ä|ae)ck|checked baggage|handgep(ä|ae)ck|carry-on)\b/i,
+      weight: 2,
+    },
+    { id: "checkin-online", pattern: /\b(online[- ]check[- ]?in|web check[- ]?in)\b/i, weight: 2 },
+    {
+      id: "airport-word",
+      pattern: /\b(flughafen|airport|abflug|departure|ankunft|arrival)\b/i,
+      weight: 2,
+    },
+    { id: "flight-noun", pattern: /\b(flug|flight|airline|fluggesellschaft)\b/i, weight: 1 },
+  ],
+  cruise: [
+    // Only a ship has a cabin and a deck together, and only a cruise has a
+    // day at sea.
+    {
+      id: "cabin-deck",
+      pattern: /\b(kabine|stateroom|cabin)\b[\s\S]{0,80}\b(deck|deck\s*\d)/i,
+      weight: 5,
+    },
+    { id: "sea-day", pattern: /\b(seetag|day at sea|erholung auf see)\b/i, weight: 5 },
+    {
+      id: "embarkation",
+      pattern: /\b(einschiffung|ausschiffung|embarkation|disembarkation)\b/i,
+      weight: 5,
+    },
+    {
+      id: "cruise-line",
+      pattern:
+        /\b(aida|tui cruises|mein schiff|msc kreuzfahrten|costa kreuzfahrten|norwegian cruise|royal caribbean|hapag[- ]lloyd cruises)\b/i,
+      weight: 3,
+    },
+    { id: "port-call", pattern: /\b(hafen|anlaufhafen|port of call|liegezeit)\b/i, weight: 3 },
+    {
+      id: "on-board",
+      pattern: /\b(an bord|on board|bordguthaben|trinkgeld an bord)\b/i,
+      weight: 3,
+    },
+    { id: "ship-noun", pattern: /\b(schiff|kreuzfahrt|cruise|sailing)\b/i, weight: 2 },
+    {
+      id: "cabin-noun",
+      pattern: /\b(kabine|stateroom|cabin|balkonkabine|innenkabine)\b/i,
+      weight: 1,
+    },
+  ],
+  lodging: [
+    // A check-in date beside a check-out date is the lodging shape. The word
+    // "Hotel" on its own is not — it appears in half of all airline mail.
+    {
+      id: "checkin-checkout",
+      pattern: /\b(check[- ]?in|anreise)\b[\s\S]{0,200}\b(check[- ]?out|abreise)\b/i,
+      weight: 5,
+    },
+    {
+      id: "nights",
+      pattern: /\b(\d+\s*(n(ä|ae)chte?|nights?|(ü|ue)bernachtungen?))\b/i,
+      weight: 5,
+    },
+    {
+      id: "room-category",
+      pattern:
+        /\b(doppelzimmer|einzelzimmer|zimmerkategorie|room type|suite|apartment|ferienwohnung)\b/i,
+      weight: 3,
+    },
+    {
+      id: "board",
+      pattern:
+        /\b(fr(ü|ue)hst(ü|ue)ck inklusive|halbpension|vollpension|all[- ]inclusive|breakfast included)\b/i,
+      weight: 3,
+    },
+    {
+      id: "platform",
+      pattern: /\b(booking\.com|expedia|hrs|airbnb|hotels\.com|agoda|trivago)\b/i,
+      weight: 3,
+    },
+    { id: "guests", pattern: /\b(\d+\s*(g(ä|ae)ste?|erwachsene|guests?|adults?))\b/i, weight: 2 },
+    {
+      id: "stay-noun",
+      pattern: /\b(unterkunft|aufenthalt|accommodation|lodging|stay)\b/i,
+      weight: 2,
+    },
+    { id: "hotel-noun", pattern: /\b(hotel|pension|hostel|gasthof)\b/i, weight: 1 },
+  ],
+};
+
+/**
+ * The score above which the evidence is considered substantial rather than
+ * incidental. Two structural hits, or one structural plus two supporting.
+ * Below it, confidence is damped proportionally — see `scoreDocument`.
+ */
+const SUBSTANTIAL_SCORE = 10;
+
+/** How much text is examined. A confirmation announces itself early, and an
+ *  unbounded scan makes the cost depend on the size of somebody's mail thread. */
+const SCAN_LIMIT = 20_000;
+
+export interface DomainScore {
+  domain: ParserSupportedDomain;
+  /** Summed weight of the distinct signals matched. */
+  score: number;
+  /** Share of the leader's evidence, damped for thin evidence. 0…1. */
+  confidence: number;
+  /** Which signals fired, so a wrong answer can be argued with rather than retried. */
+  matched: string[];
+}
+
+export interface DomainDetection {
+  /** The leading domain. Never null — see the header: this does not refuse. */
+  domain: ParserSupportedDomain;
+  confidence: number;
+  /** Every domain, best first. The client can offer a switch without asking again. */
+  candidates: DomainScore[];
+}
+
+/**
+ * Score one document against all three domains.
+ *
+ * Ties are broken by the order of `PARSER_SUPPORTED_DOMAINS`, which puts flight
+ * first — the historical default. A tie means the evidence did not decide, and
+ * preserving the old behaviour there is the least surprising thing to do.
+ */
+export function scoreDocument(text: string): DomainDetection {
+  const haystack = text.slice(0, SCAN_LIMIT);
+
+  const scored = PARSER_SUPPORTED_DOMAINS.map((domain) => {
+    const matched: string[] = [];
+    let score = 0;
+    for (const signal of SIGNALS[domain]) {
+      // Rule 1: once per signal, however often it occurs.
+      if (signal.pattern.test(haystack)) {
+        matched.push(signal.id);
+        score += signal.weight;
+      }
+    }
+    return { domain, score, matched, confidence: 0 };
+  });
+
+  const total = scored.reduce((sum, entry) => sum + entry.score, 0);
+  const leader = scored.reduce((best, entry) => (entry.score > best.score ? entry : best));
+
+  /**
+   * Rule 3. The share of the evidence pointing at a domain, multiplied by how
+   * much evidence there was at all. A single weak match that nothing
+   * contradicts scores 1.0 on share and would otherwise be reported as
+   * certainty; the damping turns it into 0.1, which is what it is worth.
+   */
+  const withConfidence = scored.map((entry) => ({
+    ...entry,
+    confidence:
+      total === 0
+        ? 0
+        : round2((entry.score / total) * Math.min(1, entry.score / SUBSTANTIAL_SCORE)),
+  }));
+
+  return {
+    domain: leader.score > 0 ? leader.domain : PARSER_SUPPORTED_DOMAINS[0],
+    confidence: withConfidence.find((e) => e.domain === leader.domain)?.confidence ?? 0,
+    // Ties fall back to the same order the leader was picked in, NOT to
+    // alphabetical — otherwise a tie makes `candidates[0]` disagree with
+    // `domain` (every evidence-free document sorted `cruise` to the front while
+    // the leader was `flight`), and the client renders a switch offer whose
+    // first entry contradicts the answer beside it.
+    candidates: [...withConfidence].sort(
+      (a, b) => b.score - a.score || domainOrder(a.domain) - domainOrder(b.domain)
+    ),
+  };
+}
+
+const round2 = (value: number): number => Math.round(value * 100) / 100;
+
+/** Position in the canonical domain order — the one tie-break this file uses. */
+const domainOrder = (domain: ParserSupportedDomain): number =>
+  PARSER_SUPPORTED_DOMAINS.indexOf(domain);

--- a/backend/src/services/parsing/parseDocument.ts
+++ b/backend/src/services/parsing/parseDocument.ts
@@ -1,0 +1,177 @@
+/**
+ * One document in, one domain-shaped answer out — Forgejo #57.
+ *
+ * `/parse-email`, `/parse-email-file` and `/parse-pdf` each carried the same
+ * three-way `if (domain === 'cruise') … if (domain === 'lodging') … else flight`
+ * block, with the subject-and-text combining copied three times too. Three
+ * copies of one dispatch is three places for the domains to fall out of step,
+ * and a fourth entry point (an image, Forgejo #58) would have made four.
+ *
+ * So the dispatch lives here once, and `auto` becomes possible as a side
+ * effect: resolving a domain is now one function call in front of a switch,
+ * rather than a change to every route.
+ *
+ * ## What `auto` does and does not promise
+ *
+ * It classifies (`documentDomain.ts`), then parses with the winner. It does NOT
+ * cascade: if the chosen parser finds nothing, the runner-up is not tried. That
+ * would double the latency of the common case to rescue the rare one, and it is
+ * unnecessary — the answer carries `detection.candidates`, so a client that
+ * disagrees can re-ask with an explicit domain and get the other reading in one
+ * further call it controls. That is the issue's own design, and it keeps the
+ * decision with the user rather than burying a guess in the server.
+ *
+ * ## Why the subject is part of the evidence
+ *
+ * The classifier reads the same combined text the parsers do, subject included.
+ * A booking confirmation announces itself in its subject line more reliably
+ * than anywhere else — "Ihre Buchungsbestätigung AIDAnova" is decisive, and
+ * scoring only the body would throw that away.
+ */
+
+import { parseBookingEmail, parseBookingText, type ParseResult } from "../bookingParser";
+import { parseCruiseBookingText } from "../cruiseBookingParser";
+import { resolveCruiseEntities, hydrateResolvedCruises } from "../cruiseEntityResolver";
+import { parseLodgingBookingText } from "../lodging/lodgingBookingParser";
+import { bookingsToCandidates } from "../lodging/lodgingCandidates";
+import { PARSER_SUPPORTED_DOMAINS, type ParserSupportedDomain } from "../../shared/domains";
+import { scoreDocument, type DomainDetection } from "./documentDomain";
+
+/** What a caller may ask for. `auto` is the addition — see the header. */
+export const REQUESTABLE_DOMAINS = [...PARSER_SUPPORTED_DOMAINS, "auto"] as const;
+export type RequestedDomain = (typeof REQUESTABLE_DOMAINS)[number];
+
+/**
+ * Where the text came from, named for what it MEANS rather than for the route.
+ *
+ * `email` may carry a subject and an HTML part, and the flight parser uses both
+ * — a header can date a mail whose body does not (#285). `document` is plain
+ * extracted text with neither.
+ */
+export type DocumentSource = "email" | "document";
+
+export interface ParseDocumentInput {
+  text: string;
+  subject?: string;
+  html?: string;
+  domain: RequestedDomain;
+  source: DocumentSource;
+  userId?: string;
+}
+
+type CruiseBody = {
+  domain: "cruise";
+  cruises: Awaited<ReturnType<typeof hydrateResolvedCruises>>;
+  parserUsed: string;
+  ollamaAvailable: boolean;
+};
+
+type LodgingBody = {
+  domain: "lodging";
+  candidates: ReturnType<typeof bookingsToCandidates>;
+  parserUsed: string;
+  ollamaAvailable: boolean;
+  fallbackReason?: string;
+};
+
+type FlightBody = { domain: "flight" } & ParseResult;
+
+/** The domain-shaped payload, byte-identical to what each route returned before. */
+export type ParsedDocumentBody = FlightBody | CruiseBody | LodgingBody;
+
+export interface ParseDocumentOutcome {
+  /** The domain actually parsed with. */
+  domain: ParserSupportedDomain;
+  /**
+   * Whether the caller named the domain or the server decided it. A client that
+   * sent `auto` must be able to tell that a decision was made on its behalf —
+   * silently answering as if it had asked for `flight` is how the "send it three
+   * times" workaround survives.
+   */
+  domainSource: "requested" | "detected";
+  /** Present only when the domain was detected: the evidence and the runners-up. */
+  detection?: DomainDetection;
+  body: ParsedDocumentBody;
+}
+
+/**
+ * The text a parser sees. Subject first, because that is where a confirmation
+ * names itself, and a blank line so the two cannot run together into a token
+ * that is in neither.
+ */
+export function combineSubjectAndText(subject: string | undefined, text: string): string {
+  return subject ? `${subject}\n\n${text}` : text;
+}
+
+/**
+ * A named step rather than a ternary, because it is the one place where the
+ * server decides something the caller did not — and `detection` being present
+ * is exactly what marks that in the answer.
+ */
+function resolveDomain(
+  requested: RequestedDomain,
+  combined: string
+): { domain: ParserSupportedDomain; detection?: DomainDetection } {
+  if (requested !== "auto") return { domain: requested };
+  const detection = scoreDocument(combined);
+  return { domain: detection.domain, detection };
+}
+
+export async function parseDocument(input: ParseDocumentInput): Promise<ParseDocumentOutcome> {
+  const combined = combineSubjectAndText(input.subject, input.text);
+  const { domain, detection } = resolveDomain(input.domain, combined);
+
+  const body = await parseAs(domain, input, combined);
+
+  return {
+    domain,
+    domainSource: detection ? "detected" : "requested",
+    ...(detection ? { detection } : {}),
+    body,
+  };
+}
+
+async function parseAs(
+  domain: ParserSupportedDomain,
+  input: ParseDocumentInput,
+  combined: string
+): Promise<ParsedDocumentBody> {
+  if (domain === "cruise") {
+    const result = await parseCruiseBookingText(combined);
+    const resolved = await Promise.all(result.cruises.map(resolveCruiseEntities));
+    return {
+      domain: "cruise",
+      cruises: await hydrateResolvedCruises(resolved, input.userId),
+      parserUsed: result.parserUsed,
+      ollamaAvailable: result.ollamaAvailable,
+    };
+  }
+
+  if (domain === "lodging") {
+    const result = await parseLodgingBookingText(combined);
+    return {
+      domain: "lodging",
+      candidates: bookingsToCandidates(result.bookings),
+      parserUsed: result.parserUsed,
+      ollamaAvailable: result.ollamaAvailable,
+      ...(result.fallbackReason !== undefined ? { fallbackReason: result.fallbackReason } : {}),
+    };
+  }
+
+  // The flight parser has two entry points and they are not interchangeable:
+  // the email one reads the subject and the HTML part, and a header is what
+  // dates a mail whose body carries a year-less date (#285). Handing plain
+  // extracted text to the email entry point would claim a subject that does
+  // not exist.
+  const result =
+    input.source === "email"
+      ? await parseBookingEmail(
+          input.subject,
+          input.text,
+          input.html,
+          input.userId ? { userId: input.userId } : undefined
+        )
+      : await parseBookingText(input.text, input.userId);
+
+  return { domain: "flight", ...result };
+}


### PR DESCRIPTION
Closes the two requests filed from the Companion side: `domain: 'auto'` (forgejo#57) and an image route that is not flight-only (forgejo#58). Together they make a pasted mail, a PDF and a photograph three doors into one behaviour.

## `domain: 'auto'`

The enabling change is not the classifier. `/parse-email`, `/parse-email-file` and `/parse-pdf` each carried the same three-way branch, with the subject-and-text combining copied three times — so `auto` would have been a change to every route, and the new image route would have made a fourth copy. The dispatch now lives once in `services/parsing/parseDocument.ts`.

Detection is a weighted signal scorer, **not** the LLM: that path exists only where an admin configured Ollama, and preview hardware measured 0.3 tokens/second. Three scoring rules, each from a bug this repo already paid for — a signal counts once however often it repeats (#17, #35); a bare noun is weak and a structure is strong; thin evidence means low confidence even when unanimous. It never refuses, and it reports the signals that fired so a wrong answer can be argued with.

## `POST /parse-image`

An image could only ever become a flight. `/parse-boardingpass` answers 501 for anything else, and `/parse-pdf` handles all three domains but needs text and refuses a scan — so a photographed hotel bill had no way in. This adds only the missing step, pixels to text.

A **second** Tesseract worker (`eng+deu`), leaving the boarding-pass one untouched: the lodging parser matches on "Nächte", and English-only training data loses the umlaut. Widening the existing worker would have risked more than it gained — the language pack is fetched at first use, so an air-gapped instance would then create no worker at all and lose working boarding-pass scanning. The new one degrades to English by itself.

## Compatibility

**An explicitly named domain keeps its exact previous response.** `domainSource` and `detection` appear only when the server decided. The three suites pinning those shapes are unchanged and green.

## Fixed in passing — found while testing, none introduced here

- `boardingPassParseLimiter` was keyed by **IP**, alone among the limiters in that file. Behind a reverse proxy that is one shared budget for everybody on the most expensive endpoint in the app. Now `userOrIpKey`, like its siblings.
- The 422 gate judged the trimmed OCR length while the response reported the untrimmed one.
- The base64 size cap could never fire against the real decoded cap.

And one that **was** mine, caught by the new tests: on a tie the reported domain and `candidates[0]` disagreed, so every evidence-free document answered `{domain: "flight", candidates: [cruise, …]}`. That list is what a client offers a switch from, so it was user-visible. Pinned by a regression test.

## Test plan

- [x] `npx tsc --noEmit` + `npm run lint` clean (backend)
- [x] 15 suites / 141 tests green, 46 new (37 classifier, 9 route)
- [x] `parser.domain.test.ts`, `emailParse.cruise.test.ts`, `lodgingParseRoutes.test.ts` unchanged and green — these pin the response shapes
- [x] OpenAPI coverage guard green; `/parse-image` documented incl. 422
- [ ] Manual: photograph a German hotel bill and confirm it lands as `lodging` (needs the `deu` language pack to download once)
- [ ] Manual: confirm boarding-pass scanning still works after the limiter key change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
